### PR TITLE
Feature/3752: API Endpoints for Import Linearity - Test Summary Data

### DIFF
--- a/src/linearity-injection-workspace/linearity-injection.service.spec.ts
+++ b/src/linearity-injection-workspace/linearity-injection.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import {
+  LinearityInjectionImportDTO,
+  LinearityInjectionRecordDTO,
+} from '../dto/linearity-injection.dto';
+import { LinearitySummaryDTO } from '../dto/linearity-summary.dto';
+import { LinearityInjectionWorkspaceService } from './linearity-injection.service';
+import { LinearityInjectionWorkspaceRepository } from './linearity-injection.repository';
+import { LinearityInjectionMap } from '../maps/linearity-injection.map';
+import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
+
+const testSumId = '1';
+const linSumId = '1';
+const userId = 'testuser';
+
+const lineInjectionDto = new LinearitySummaryDTO();
+const lineInjectionRecordDto = new LinearityInjectionRecordDTO();
+
+const payload = new LinearityInjectionImportDTO();
+
+const mockRepository = () => ({});
+
+const mockTestSummaryService = () => ({});
+
+const mockMap = () => ({
+  one: jest.fn().mockResolvedValue(lineInjectionDto),
+  many: jest.fn().mockResolvedValue([lineInjectionDto]),
+});
+
+describe('TestSummaryWorkspaceService', () => {
+  let service: LinearityInjectionWorkspaceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule],
+      providers: [
+        LinearityInjectionWorkspaceService,
+        {
+          provide: TestSummaryWorkspaceService,
+          useFactory: mockTestSummaryService,
+        },
+        {
+          provide: LinearityInjectionWorkspaceRepository,
+          useFactory: mockRepository,
+        },
+        {
+          provide: LinearityInjectionMap,
+          useFactory: mockMap,
+        },
+      ],
+    }).compile();
+
+    service = module.get(LinearityInjectionWorkspaceService);
+  });
+
+  describe('import', () => {
+    it('Should import Linearity Summary', async () => {
+      jest
+        .spyOn(service, 'createInjection')
+        .mockResolvedValue(lineInjectionRecordDto);
+      const result = await service.import(testSumId, linSumId, payload, userId);
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/src/linearity-injection-workspace/linearity-injection.service.ts
+++ b/src/linearity-injection-workspace/linearity-injection.service.ts
@@ -16,6 +16,7 @@ import {
   LinearityInjectionDTO,
   LinearityInjectionBaseDTO,
   LinearityInjectionRecordDTO,
+  LinearityInjectionImportDTO,
 } from '../dto/linearity-injection.dto';
 
 import { currentDateTime } from '../utilities/functions';
@@ -59,8 +60,25 @@ export class LinearityInjectionWorkspaceService {
     return this.getInjectionsByLinSumIds(linSumIds);
   }
 
-  async import() {
+  async import(
+    testSumId: string,
+    linSumId: string,
+    payload: LinearityInjectionImportDTO,
+    userId: string,
+  ) {
     const isImport = true;
+    const result = await this.createInjection(
+      testSumId,
+      linSumId,
+      payload,
+      userId,
+      isImport,
+    );
+
+    this.logger.info(
+      `Linearity Injection Successfully Imported. Record Id: ${result.id}`,
+    );
+    return null;
   }
 
   async createInjection(

--- a/src/linearity-summary-workspace/linearity-summary.service.spec.ts
+++ b/src/linearity-summary-workspace/linearity-summary.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { LinearityInjectionImportDTO } from '../dto/linearity-injection.dto';
+import {
+  LinearitySummaryDTO,
+  LinearitySummaryImportDTO,
+  LinearitySummaryRecordDTO,
+} from '../dto/linearity-summary.dto';
+import { LinearityInjectionWorkspaceService } from '../linearity-injection-workspace/linearity-injection.service';
+import { LinearitySummaryMap } from '../maps/linearity-summary.map';
+import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
+import { LinearitySummaryWorkspaceRepository } from './linearity-summary.repository';
+import { LinearitySummaryWorkspaceService } from './linearity-summary.service';
+
+const testSumId = '1';
+const userId = 'testuser';
+
+const lineSummaryDto = new LinearitySummaryDTO();
+const lineSummaryRecordDto = new LinearitySummaryRecordDTO();
+
+const payload = new LinearitySummaryImportDTO();
+payload.linearityInjectionData = [new LinearityInjectionImportDTO()];
+
+const mockRepository = () => ({});
+
+const mockTestSummaryService = () => ({});
+
+const mockLinearityInjectionService = () => ({
+  import: jest.fn().mockResolvedValue(null),
+});
+
+const mockMap = () => ({
+  one: jest.fn().mockResolvedValue(lineSummaryDto),
+  many: jest.fn().mockResolvedValue([lineSummaryDto]),
+});
+
+describe('TestSummaryWorkspaceService', () => {
+  let service: LinearitySummaryWorkspaceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule],
+      providers: [
+        LinearitySummaryWorkspaceService,
+        {
+          provide: TestSummaryWorkspaceService,
+          useFactory: mockTestSummaryService,
+        },
+        {
+          provide: LinearityInjectionWorkspaceService,
+          useFactory: mockLinearityInjectionService,
+        },
+        {
+          provide: LinearitySummaryWorkspaceRepository,
+          useFactory: mockRepository,
+        },
+        {
+          provide: LinearitySummaryMap,
+          useFactory: mockMap,
+        },
+      ],
+    }).compile();
+
+    service = module.get(LinearitySummaryWorkspaceService);
+  });
+
+  describe('import', () => {
+    it('Should import Linearity Summary', async () => {
+      jest
+        .spyOn(service, 'createSummary')
+        .mockResolvedValue(lineSummaryRecordDto);
+      const result = await service.import(testSumId, payload, userId);
+      expect(result).toEqual(null);
+    });
+  });
+});

--- a/src/linearity-summary-workspace/linearity-summary.service.ts
+++ b/src/linearity-summary-workspace/linearity-summary.service.ts
@@ -92,10 +92,7 @@ export class LinearitySummaryWorkspaceService {
       `Linear Summary Successfully Imported. Record Id: ${createdLineSummary.id}`,
     );
 
-    if (
-      payload.linearityInjectionData &&
-      payload.linearityInjectionData.length > 0
-    ) {
+    if (payload.linearityInjectionData?.length > 0) {
       for (const injection of payload.linearityInjectionData) {
         promises.push(
           new Promise(async (resolve, _reject) => {

--- a/src/linearity-summary-workspace/linearity-summary.service.ts
+++ b/src/linearity-summary-workspace/linearity-summary.service.ts
@@ -88,6 +88,10 @@ export class LinearitySummaryWorkspaceService {
       isImport,
     );
 
+    this.logger.info(
+      `Linear Summary Successfully Imported. Record Id: ${createdLineSummary.id}`,
+    );
+
     if (
       payload.linearityInjectionData &&
       payload.linearityInjectionData.length > 0
@@ -113,9 +117,6 @@ export class LinearitySummaryWorkspaceService {
 
     await Promise.all(promises);
 
-    this.logger.info(
-      `Linear Summary Successfully Imported. Record Id: ${createdLineSummary.id}`,
-    );
     return null;
   }
 

--- a/src/qa-certification-workspace/qa-certification-workspace.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification-workspace.service.spec.ts
@@ -1,16 +1,39 @@
 import { Test } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import {
+  QACertificationDTO,
+  QACertificationImportDTO,
+} from '../dto/qa-certification.dto';
 import { QACertificationParamsDTO } from '../dto/qa-certification-params.dto';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { QACertificationWorkspaceService } from './qa-certification-workspace.service';
+import { TestSummaryDTO, TestSummaryImportDTO } from '../dto/test-summary.dto';
+
+const testSummary = new TestSummaryDTO();
+const qaCertDto = new QACertificationDTO();
+qaCertDto.testSummaryData = [testSummary];
+
+const payload = new QACertificationImportDTO();
+payload.testSummaryData = [new TestSummaryImportDTO()];
+payload.testSummaryData[0].unitId = '1';
+payload.testSummaryData[0].stackPipeId = '1';
+
+const userId = 'testUser';
+
+const location = {
+  unitId: '1',
+  locationId: '1',
+  stackPipeId: '1',
+  systemIds: ['1'],
+  componentIds: ['1'],
+};
+const mockTestSummaryWorkspaceService = () => ({
+  export: jest.fn().mockResolvedValue([testSummary]),
+  import: jest.fn().mockResolvedValue(undefined),
+});
 
 describe('QA Certification Workspace Service Test', () => {
   let service: QACertificationWorkspaceService;
-  let testSummaryService: any;
-
-  const mockTestSummaryWorkspaceService = () => ({
-    export: jest.fn(),
-  });
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -25,17 +48,28 @@ describe('QA Certification Workspace Service Test', () => {
     }).compile();
 
     service = module.get(QACertificationWorkspaceService);
-    testSummaryService = module.get(TestSummaryWorkspaceService);
   });
 
-  describe('export test', () => {
+  describe('export', () => {
     it('successfully calls export() service function', async () => {
+      const expected = qaCertDto;
+      expected.testSummaryData = [testSummary];
+      expected.testExtensionExemptionData = undefined;
+      expected.certificationEventData = undefined;
+      expected.orisCode = 1;
+
       const paramsDTO = new QACertificationParamsDTO();
-      const expected = { testSummaryData: [] };
-      testSummaryService.export.mockResolvedValue([]);
+      paramsDTO.facilityId = 1;
       const result = await service.export(paramsDTO);
 
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('import', () => {
+    it('successfully calls import() service function', async () => {
+      const result = await service.import([location], payload, userId);
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -141,7 +141,7 @@ describe('TestSummaryWorkspaceService', () => {
       const result = await service.import(locationId, payload, userId);
 
       expect(creste).toHaveBeenCalled();
-      expect(result).toEqual(undefined);
+      expect(result).toEqual(null);
     });
   });
 

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -5,7 +5,10 @@ import { TestSummaryDTO, TestSummaryImportDTO } from '../dto/test-summary.dto';
 import { TestSummaryMap } from '../maps/test-summary.map';
 import { TestSummaryWorkspaceRepository } from './test-summary.repository';
 import { TestSummaryWorkspaceService } from './test-summary.service';
-import { LinearitySummaryDTO } from '../dto/linearity-summary.dto';
+import {
+  LinearitySummaryDTO,
+  LinearitySummaryImportDTO,
+} from '../dto/linearity-summary.dto';
 import { TestSummary } from '../entities/workspace/test-summary.entity';
 import * as utils from '../utilities/utils';
 import { MonitorLocation } from '../entities/monitor-location.entity';
@@ -22,6 +25,7 @@ const userId = 'testuser';
 const testSummary = new TestSummary();
 const testSummaryDto = new TestSummaryDTO();
 const lineSumDto = new LinearitySummaryDTO();
+const lineSumImportDto = new LinearitySummaryImportDTO();
 lineSumDto.testSumId = testSumId;
 
 const payload = new TestSummaryImportDTO();
@@ -29,6 +33,7 @@ payload.testTypeCode = 'code';
 payload.testNumber = '1';
 payload.unitId = '1';
 payload.stackPipeId = '1';
+payload.linearitySummaryData = [lineSumImportDto];
 
 const mockRepository = () => ({
   getTestSummaryById: jest.fn().mockResolvedValue(testSummary),
@@ -42,6 +47,7 @@ const mockRepository = () => ({
 
 const mockLinearitySummaryService = () => ({
   export: jest.fn().mockResolvedValue([lineSumDto]),
+  import: jest.fn().mockResolvedValue(null),
 });
 
 const mockMap = () => ({

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -153,10 +153,7 @@ export class TestSummaryWorkspaceService {
       `Test Summary Successfully Imported. Record Id: ${createdTestSummary.id}`,
     );
 
-    if (
-      payload.linearitySummaryData &&
-      payload.linearitySummaryData.length > 0
-    ) {
+    if (payload.linearitySummaryData?.length > 0) {
       for (const linearitySummary of payload.linearitySummaryData) {
         promises.push(
           new Promise(async (resolve, _reject) => {

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -149,6 +149,10 @@ export class TestSummaryWorkspaceService {
       userId,
     );
 
+    this.logger.info(
+      `Test Summary Successfully Imported. Record Id: ${createdTestSummary.id}`,
+    );
+
     if (
       payload.linearitySummaryData &&
       payload.linearitySummaryData.length > 0
@@ -173,9 +177,6 @@ export class TestSummaryWorkspaceService {
 
     await Promise.all(promises);
 
-    this.logger.info(
-      `Test Summary Successfully Imported. Record Id: ${createdTestSummary.id}`,
-    );
     return null;
   }
 
@@ -215,7 +216,7 @@ export class TestSummaryWorkspaceService {
       );
     }
 
-    let entity = this.repository.create({
+    const entity = this.repository.create({
       ...payload,
       id: uuid(),
       locationId,
@@ -232,7 +233,6 @@ export class TestSummaryWorkspaceService {
     });
 
     await this.repository.save(entity);
-    console.log('Created Test Summary:', entity.id);
     const result = await this.repository.getTestSummaryById(entity.id);
 
     const dto = await this.map.one(result);


### PR DESCRIPTION
## [Feature/3752: API Endpoints for Import Linearity - Test Summary Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3752)

### Unit Tests.

- Added Unit Tests for Import of Linearity Summary and Linearity Injection
![image](https://user-images.githubusercontent.com/102534033/176503799-266e851a-aef1-438a-8e5e-dcf7119d4180.png)

- Added Unit Tests for Import of Test Summary and QA Cert 
![image](https://user-images.githubusercontent.com/102534033/176503443-8821b215-723b-4c30-b713-dd1de41d57fe.png)

