### PR TITLE
Feature/3137: Remove API Endpoint - Linearity Injection Data

### DIFF
--- a/src/linearity-injection-workspace/linearity-injection.controller.spec.ts
+++ b/src/linearity-injection-workspace/linearity-injection.controller.spec.ts
@@ -27,6 +27,8 @@ const payload: LinearityInjectionBaseDTO = {
 };
 
 const mockService = () => ({
+  getInjectionsByLinSumId: jest.fn().mockResolvedValue([linInjDto]),
+  getInjectionById: jest.fn().mockResolvedValue(linInjDto),
   createInjection: jest.fn().mockResolvedValue(linInjDto),
   updateInjection: jest.fn().mockResolvedValue(linInjDto),
   deleteInjection: jest.fn().mockResolvedValue(null),
@@ -62,6 +64,25 @@ describe('Linearity Injection Controller', () => {
     controller = module.get(LinearityInjectionWorkspaceController);
     service = module.get(LinearityInjectionWorkspaceService);
     checkService = module.get(LinearityInjectionChecksService);
+  });
+
+  describe('getInjections', () => {
+    it('should get Linearity injection records by Linearity Summary Id', async () => {
+      const result = await controller.getInjections(locId, testSumId, linSumId);
+      expect(result).toEqual([linInjDto]);
+    });
+  });
+
+  describe('getLinearityInjection', () => {
+    it('should get Linearity injection record', async () => {
+      const result = await controller.getLinearityInjection(
+        locId,
+        testSumId,
+        linSumId,
+        linInjId,
+      );
+      expect(result).toEqual(linInjDto);
+    });
   });
 
   describe('createLinearityInjection', () => {

--- a/src/linearity-injection-workspace/linearity-injection.controller.spec.ts
+++ b/src/linearity-injection-workspace/linearity-injection.controller.spec.ts
@@ -29,6 +29,7 @@ const payload: LinearityInjectionBaseDTO = {
 const mockService = () => ({
   createInjection: jest.fn().mockResolvedValue(linInjDto),
   updateInjection: jest.fn().mockResolvedValue(linInjDto),
+  deleteInjection: jest.fn().mockResolvedValue(null),
 });
 
 const mockCheckService = () => ({
@@ -89,6 +90,18 @@ describe('Linearity Injection Controller', () => {
       );
       expect(result).toEqual(linInjDto);
       expect(spyCheckService).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteLinearityInjection', () => {
+    it('should delete Linearity injection record', async () => {
+      const result = await controller.deleteLinearityInjection(
+        locId,
+        testSumId,
+        linSumId,
+        linInjId,
+      );
+      expect(result).toEqual(null);
     });
   });
 });

--- a/src/linearity-injection-workspace/linearity-injection.repository.ts
+++ b/src/linearity-injection-workspace/linearity-injection.repository.ts
@@ -4,14 +4,4 @@ import { LinearityInjection } from '../entities/workspace/linearity-injection.en
 @EntityRepository(LinearityInjection)
 export class LinearityInjectionWorkspaceRepository extends Repository<
   LinearityInjection
-> {
-  async getInjectionsByLinSumId(
-    linSumId: string,
-  ): Promise<LinearityInjection[]> {
-    return this.createQueryBuilder('li')
-      .where('li.linSumId = :linSumId', {
-        linSumId,
-      })
-      .getMany();
-  }
-}
+> {}

--- a/src/linearity-injection-workspace/linearity-injection.service.ts
+++ b/src/linearity-injection-workspace/linearity-injection.service.ts
@@ -39,13 +39,23 @@ export class LinearityInjectionWorkspaceService {
 
   async getInjectionById(id: string): Promise<LinearityInjectionDTO> {
     const result = await this.repository.findOne(id);
+
+    if (!result) {
+      throw new LoggingException(
+        'Invalid Linearity Injection Id',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
     return this.map.one(result);
   }
 
   async getInjectionsByLinSumId(
     linSumId: string,
   ): Promise<LinearityInjectionDTO[]> {
-    const results = await this.repository.getInjectionsByLinSumId(linSumId);
+    const results = await this.repository.find({
+      linSumId: linSumId,
+    });
     return this.map.many(results);
   }
 

--- a/src/maps/protocol-gas.map.spec.ts
+++ b/src/maps/protocol-gas.map.spec.ts
@@ -13,8 +13,8 @@ entity.vendorID = string;
 entity.cylinderID = string;
 entity.expirationDate = date;
 entity.userId = string;
-entity.addDate = date;
-entity.updateDate = date;
+entity.addDate = string;
+entity.updateDate = string;
 
 describe('ProtocolGasMap', () => {
   it('maps an entity to a dto', async () => {
@@ -28,7 +28,7 @@ describe('ProtocolGasMap', () => {
     expect(result.cylinderID).toEqual(string);
     expect(result.expirationDate).toEqual(date);
     expect(result.userId).toEqual(string);
-    expect(result.addDate).toEqual(date);
-    expect(result.updateDate).toEqual(date);
+    expect(result.addDate).toEqual(string);
+    expect(result.updateDate).toEqual(string);
   });
 });

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import {
   BadRequestException,
   forwardRef,
+  HttpStatus,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -33,6 +34,7 @@ import { MonitorLocation } from './../entities/workspace/monitor-location.entity
 import { ReportingPeriod } from './../entities/workspace/reporting-period.entity';
 
 import { getEntityManager } from '../utilities/utils';
+import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
 
 @Injectable()
 export class TestSummaryWorkspaceService {
@@ -49,6 +51,10 @@ export class TestSummaryWorkspaceService {
     const result = await this.repository.getTestSummaryById(testSumId);
 
     if (!result) {
+      throw new LoggingException(
+        'Invalid Test Summary Id',
+        HttpStatus.NOT_FOUND,
+      );
     }
 
     return this.map.one(result);
@@ -211,6 +217,12 @@ export class TestSummaryWorkspaceService {
       (unit && payload.unitId !== unit.name) ||
       (stackPipe && payload.stackPipeId !== stackPipe.name)
     ) {
+      throw new LoggingException(
+        `The provided Location Id [${locationId}] does not match the provided Unit/Stack [${
+          payload.unitId ? payload.unitId : payload.stackPipeId
+        }]`,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const entity = this.repository.create({
@@ -265,6 +277,10 @@ export class TestSummaryWorkspaceService {
     const entity = await this.repository.getTestSummaryById(id);
 
     if (!entity) {
+      throw new LoggingException(
+        'Invalid Test Summary Id',
+        HttpStatus.NOT_FOUND,
+      );
     }
 
     const [


### PR DESCRIPTION
## [Feature/3137: Remove API Endpoint - Linearity Injection Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3137)
