### PR TITLE
Feature/3101: Remove (DELETE) API Endpoint - RATA Data

### DIFF
--- a/src/linearity-injection-workspace/linearity-injection.service.ts
+++ b/src/linearity-injection-workspace/linearity-injection.service.ts
@@ -1,13 +1,7 @@
 import { In } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
-import {
-  forwardRef,
-  HttpStatus,
-  Inject,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
 
@@ -164,9 +158,9 @@ export class LinearityInjectionWorkspaceService {
     try {
       await this.repository.delete(id);
     } catch (e) {
-      throw new InternalServerErrorException(
+      throw new LoggingException(
         `Error deleting Linearity Injection record Id [${id}]`,
-        e.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
 

--- a/src/rata-workspace/rata-workspace.controller.spec.ts
+++ b/src/rata-workspace/rata-workspace.controller.spec.ts
@@ -18,6 +18,7 @@ const payload: RataBaseDTO = {
 const mockService = () => ({
   createRata: jest.fn().mockResolvedValue(rataRecord),
   updateRata: jest.fn().mockResolvedValue(rataRecord),
+  deleteRata: jest.fn().mockResolvedValue(null),
 });
 
 describe('RataWorkspaceController', () => {
@@ -52,6 +53,13 @@ describe('RataWorkspaceController', () => {
       expect(
         await controller.updateRata(locId, testSumId, rataId, payload),
       ).toEqual(rataRecord);
+    });
+  });
+
+  describe('deleteRata', () => {
+    it('should call the RataService.deleteRata and delete rata record', async () => {
+      const result = await controller.deleteRata(locId, testSumId, rataId);
+      expect(result).toEqual(null);
     });
   });
 });

--- a/src/rata-workspace/rata-workspace.controller.ts
+++ b/src/rata-workspace/rata-workspace.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, Put } from '@nestjs/common';
 import {
   ApiCreatedResponse,
   ApiOkResponse,
@@ -47,5 +47,20 @@ export class RataWorkspaceController {
     //    @CurrentUser() userId: string,
   ): Promise<RataRecordDTO> {
     return this.service.updateRata(testSumId, id, payload, userId);
+  }
+
+  @Delete(':id')
+  //  @ApiBearerAuth('Token')
+  //  @UseGuards(AuthGuard)
+  @ApiOkResponse({
+    description: 'Deletes a RATA record from the workspace',
+  })
+  async deleteRata(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    //    @CurrentUser() userId: string,
+  ): Promise<void> {
+    return this.service.deleteRata(testSumId, id, userId);
   }
 }

--- a/src/rata-workspace/rata-workspace.service.spec.ts
+++ b/src/rata-workspace/rata-workspace.service.spec.ts
@@ -5,6 +5,8 @@ import { RataMap } from '../maps/rata.map';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { RataWorkspaceRepository } from './rata-workspace.repository';
 import { RataWorkspaceService } from './rata-workspace.service';
+import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
+import { HttpStatus } from '@nestjs/common';
 
 const rataDto = new RataDTO();
 
@@ -26,6 +28,7 @@ const mockRepository = () => ({
   create: jest.fn().mockResolvedValue(rataEntity),
   save: jest.fn().mockResolvedValue(rataEntity),
   findOne: jest.fn().mockResolvedValue(rataEntity),
+  delete: jest.fn().mockResolvedValue(null),
 });
 
 const mockTestSummaryService = () => ({
@@ -93,6 +96,29 @@ describe('RataWorkspaceService', () => {
         errored = true;
       }
       expect(errored).toEqual(true);
+    });
+
+    describe('deleteRata', () => {
+      it('Should delete a Rata record', async () => {
+        const result = await service.deleteRata(testSumId, rataId, userId);
+        expect(result).toEqual(undefined);
+      });
+
+      it('Should through error while deleting a Rata record', async () => {
+        const error = new LoggingException(
+          `Error deleting RATA with record Id [${rataId}]`,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+        jest.spyOn(repository, 'delete').mockRejectedValue(error);
+
+        let errored = false;
+        try {
+          await service.deleteRata(testSumId, rataId, userId);
+        } catch (e) {
+          errored = true;
+        }
+        expect(errored).toEqual(true);
+      });
     });
   });
 });

--- a/src/rata-workspace/rata-workspace.service.ts
+++ b/src/rata-workspace/rata-workspace.service.ts
@@ -78,4 +78,26 @@ export class RataWorkspaceService {
     );
     return this.map.one(entity);
   }
+
+  async deleteRata(
+    testSumId: string,
+    id: string,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<void> {
+    try {
+      await this.repository.delete(id);
+    } catch (e) {
+      throw new LoggingException(
+        `Error deleting RATA with record Id [${id}]`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+  }
 }


### PR DESCRIPTION
## [Feature/3101: Remove (DELETE) API Endpoint - RATA Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3101)
