### PR TITLE
Feature/4142: Add Traverse Data elements to Import Endpoint

### DIFF
--- a/src/air-emission-testing/air-emission-testing.controller.spec.ts
+++ b/src/air-emission-testing/air-emission-testing.controller.spec.ts
@@ -8,7 +8,12 @@ describe('AirEmissionTestingController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AirEmissionTestingController],
-      providers: [AirEmissionTestingService],
+      providers: [
+        {
+          provide: AirEmissionTestingService,
+          useFactory: () => ({}),
+        },
+      ],
     }).compile();
 
     controller = module.get<AirEmissionTestingController>(

--- a/src/air-emission-testing/air-emission-testing.service.spec.ts
+++ b/src/air-emission-testing/air-emission-testing.service.spec.ts
@@ -1,4 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { AirEmissionTestingMap } from '../maps/air-emission-testing.map';
+import { AirEmissionTestingRepository } from './air-emission-testing.repository';
 import { AirEmissionTestingService } from './air-emission-testing.service';
 
 describe('AirEmissionTestingService', () => {
@@ -6,7 +8,11 @@ describe('AirEmissionTestingService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AirEmissionTestingService],
+      providers: [
+        AirEmissionTestingService,
+        AirEmissionTestingRepository,
+        AirEmissionTestingMap,
+      ],
     }).compile();
 
     service = module.get<AirEmissionTestingService>(AirEmissionTestingService);

--- a/src/flow-rata-run-workspace/flow-rata-run-workspace.service.spec.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-workspace.service.spec.ts
@@ -9,7 +9,10 @@ import {
   FlowRataRunDTO,
   FlowRataRunImportDTO,
 } from '../dto/flow-rata-run.dto';
-import { RataTraverseDTO } from '../dto/rata-traverse.dto';
+import {
+  RataTraverseDTO,
+  RataTraverseImportDTO,
+} from '../dto/rata-traverse.dto';
 import { RataTraverseWorkspaceService } from '../rata-traverse-workspace/rata-traverse-workspace.service';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { FlowRataRunRepository } from '../flow-rata-run/flow-rata-run.repository';
@@ -202,6 +205,7 @@ describe('FlowRataRunWorkspaceService', () => {
     });
 
     it('Should import Flow Rata Run with historical data', async () => {
+      importPayload.rataTraverseData = [new RataTraverseImportDTO()];
       jest
         .spyOn(service, 'createFlowRataRun')
         .mockResolvedValue(flowRataRunDTO);

--- a/src/flow-rata-run-workspace/flow-rata-run-workspace.service.spec.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-workspace.service.spec.ts
@@ -4,7 +4,11 @@ import { FlowRataRunWorkspaceRepository } from './flow-rata-run-workspace.reposi
 import { FlowRataRunWorkspaceService } from './flow-rata-run-workspace.service';
 import { FlowRataRun } from '../entities/workspace/flow-rata-run.entity';
 import { FlowRataRun as FlowRataRunOfficial } from '../entities/flow-rata-run.entity';
-import { FlowRataRunBaseDTO, FlowRataRunDTO, FlowRataRunImportDTO } from '../dto/flow-rata-run.dto';
+import {
+  FlowRataRunBaseDTO,
+  FlowRataRunDTO,
+  FlowRataRunImportDTO,
+} from '../dto/flow-rata-run.dto';
 import { RataTraverseDTO } from '../dto/rata-traverse.dto';
 import { RataTraverseWorkspaceService } from '../rata-traverse-workspace/rata-traverse-workspace.service';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
@@ -111,7 +115,9 @@ describe('FlowRataRunWorkspaceService', () => {
     testSummaryService = module.get<TestSummaryWorkspaceService>(
       TestSummaryWorkspaceService,
     );
-    officialRepository = module.get<FlowRataRunRepository>(FlowRataRunRepository);
+    officialRepository = module.get<FlowRataRunRepository>(
+      FlowRataRunRepository,
+    );
   });
 
   describe('getFlowRataRun', () => {
@@ -183,7 +189,9 @@ describe('FlowRataRunWorkspaceService', () => {
     const importPayload = new FlowRataRunImportDTO();
 
     it('Should import Flow Rata Run', async () => {
-      jest.spyOn(service, 'createFlowRataRun').mockResolvedValue(flowRataRunDTO);
+      jest
+        .spyOn(service, 'createFlowRataRun')
+        .mockResolvedValue(flowRataRunDTO);
       const result = await service.import(
         testSumId,
         rataRunId,
@@ -194,7 +202,9 @@ describe('FlowRataRunWorkspaceService', () => {
     });
 
     it('Should import Flow Rata Run with historical data', async () => {
-      jest.spyOn(service, 'createFlowRataRun').mockResolvedValue(flowRataRunDTO);
+      jest
+        .spyOn(service, 'createFlowRataRun')
+        .mockResolvedValue(flowRataRunDTO);
       jest
         .spyOn(officialRepository, 'findOne')
         .mockResolvedValue(officialRecord);

--- a/src/maps/rata-summary.map.spec.ts
+++ b/src/maps/rata-summary.map.spec.ts
@@ -2,6 +2,7 @@ import { RataSummary } from '../entities/rata-summary.entity';
 import { RataRunMap } from './rata-run.map';
 import { RataSummaryMap } from './rata-summary.map';
 import { FlowRataRunMap } from './flow-rata-run.map';
+import { RataTraverseMap } from './rata-traverse.map';
 
 const string = '';
 const number = 0;
@@ -50,7 +51,9 @@ entity.updateDate = date;
 
 describe('RataSummaryMap', () => {
   it('should map an entity to a dto', async () => {
-    const map = new RataSummaryMap(new RataRunMap(new FlowRataRunMap()));
+    const map = new RataSummaryMap(
+      new RataRunMap(new FlowRataRunMap(new RataTraverseMap())),
+    );
     const result = await map.one(entity);
     expect(result.id).toEqual(string);
     expect(result.rataId).toEqual(string);
@@ -97,7 +100,9 @@ describe('RataSummaryMap', () => {
     entity.addDate = undefined;
     entity.updateDate = undefined;
 
-    const map = new RataSummaryMap(new RataRunMap(new FlowRataRunMap()));
+    const map = new RataSummaryMap(
+      new RataRunMap(new FlowRataRunMap(new RataTraverseMap())),
+    );
     const result = await map.one(entity);
 
     expect(result.addDate).toEqual(null);

--- a/src/maps/rata.map.spec.ts
+++ b/src/maps/rata.map.spec.ts
@@ -3,6 +3,7 @@ import { RataRunMap } from './rata-run.map';
 import { RataSummaryMap } from './rata-summary.map';
 import { RataMap } from './rata.map';
 import { FlowRataRunMap } from './flow-rata-run.map';
+import { RataTraverseMap } from './rata-traverse.map';
 
 const string = '';
 const number = 0;
@@ -27,7 +28,9 @@ entity.rataSummaries = [];
 describe('RataMap', () => {
   it('maps an entity to a dto', async () => {
     const map = new RataMap(
-      new RataSummaryMap(new RataRunMap(new FlowRataRunMap())),
+      new RataSummaryMap(
+        new RataRunMap(new FlowRataRunMap(new RataTraverseMap())),
+      ),
     );
     const result = await map.one(entity);
     expect(result.id).toEqual(string);
@@ -51,7 +54,9 @@ describe('RataMap', () => {
     entity.updateDate = undefined;
 
     const map = new RataMap(
-      new RataSummaryMap(new RataRunMap(new FlowRataRunMap())),
+      new RataSummaryMap(
+        new RataRunMap(new FlowRataRunMap(new RataTraverseMap())),
+      ),
     );
     const result = await map.one(entity);
 

--- a/src/qa-certification-workspace/qa-certification-checks.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification-checks.service.spec.ts
@@ -14,6 +14,7 @@ import { BadRequestException } from '@nestjs/common';
 import { RataChecksService } from '../rata-workspace/rata-checks.service';
 import { RataSummaryChecksService } from '../rata-summary-workspace/rata-summary-checks.service';
 import { QASuppDataWorkspaceRepository } from '../qa-supp-data-workspace/qa-supp-data.repository';
+import { RataRunChecksService } from '../rata-run-workspace/rata-run-checks.service';
 
 const returnLocationRunChecks = [
   {
@@ -77,6 +78,12 @@ describe('QA Certification Check Service Test', () => {
         },
         {
           provide: RataSummaryChecksService,
+          useFactory: () => ({
+            runChecks: jest.fn().mockResolvedValue([]),
+          }),
+        },
+        {
+          provide: RataRunChecksService,
           useFactory: () => ({
             runChecks: jest.fn().mockResolvedValue([]),
           }),

--- a/src/qa-certification-workspace/qa-certification.module.ts
+++ b/src/qa-certification-workspace/qa-certification.module.ts
@@ -12,6 +12,8 @@ import { RataWorkspaceModule } from '../rata-workspace/rata-workspace.module';
 import { RataSummaryWorkspaceModule } from '../rata-summary-workspace/rata-summary-workspace.module';
 import { QASuppDataWorkspaceModule } from '../qa-monitor-plan-workspace/qa-monitor-plan.module';
 import { RataRunWorkspaceModule } from '../rata-run-workspace/rata-run-workspace.module';
+import { FlowRataRunWorkspaceModule } from 'src/flow-rata-run-workspace/flow-rata-run-workspace.module';
+import { RataTraverseWorkspaceModule } from 'src/rata-traverse-workspace/rata-traverse-workspace.module';
 
 @Module({
   imports: [
@@ -23,6 +25,8 @@ import { RataRunWorkspaceModule } from '../rata-run-workspace/rata-run-workspace
     RataWorkspaceModule,
     RataSummaryWorkspaceModule,
     RataRunWorkspaceModule,
+    FlowRataRunWorkspaceModule,
+    RataTraverseWorkspaceModule,
   ],
   controllers: [QACertificationWorkspaceController],
   providers: [QACertificationChecksService, QACertificationWorkspaceService],

--- a/src/qa-certification/qa-certification.controller.spec.ts
+++ b/src/qa-certification/qa-certification.controller.spec.ts
@@ -26,6 +26,12 @@ import { RataService } from '../rata/rata.service';
 import { RataRepository } from '../rata/rata.repository';
 import { RataSummaryRepository } from '../rata-summary/rata-summary.repository';
 import { RataRunRepository } from '../rata-run/rata-run.repository';
+import { FlowRataRunService } from '../flow-rata-run/flow-rata-run.service';
+import { RataTraverseService } from '../rata-traverse/rata-traverse.service';
+import { FlowRataRunRepository } from '../flow-rata-run/flow-rata-run.repository';
+import { FlowRataRunMap } from '../maps/flow-rata-run.map';
+import { RataTraverseRepository } from '../rata-traverse/rata-traverse.repository';
+import { RataTraverseMap } from '../maps/rata-traverse.map';
 
 describe('QA Certification Controller Test', () => {
   let controller: QACertificationController;
@@ -37,29 +43,10 @@ describe('QA Certification Controller Test', () => {
       imports: [LoggerModule],
       controllers: [QACertificationController],
       providers: [
-        QACertificationService,
-        ConfigService,
-        TestSummaryService,
-        TestSummaryMap,
-        LinearitySummaryService,
-        TestSummaryRepository,
-        LinearitySummaryMap,
-        LinearitySummaryRepository,
-        LinearityInjectionService,
-        LinearityInjectionMap,
-        LinearityInjectionRepository,
-        ProtocolGasMap,
-        RataRepository,
-        RataService,
-        RataMap,
-        RataSummaryRepository,
-        RataSummaryService,
-        RataSummaryMap,
-        RataRunRepository,
-        RataRunService,
-        RataRunMap,
-        TestQualificationMap,
-        AirEmissionTestingMap,
+        {
+          provide: QACertificationService,
+          useFactory: () => ({}),
+        },
       ],
     }).compile();
 

--- a/src/rata-run-workspace/rata-run-workspace.controller.spec.ts
+++ b/src/rata-run-workspace/rata-run-workspace.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RataRunBaseDTO, RataRunDTO } from '../dto/rata-run.dto';
+import { RataRunChecksService } from './rata-run-checks.service';
 import { RataRunWorkspaceController } from './rata-run-workspace.controller';
 import { RataRunWorkspaceService } from './rata-run-workspace.service';
 
@@ -45,6 +46,12 @@ describe('RataRunWorkspaceController', () => {
         {
           provide: RataRunWorkspaceService,
           useFactory: mockRataRunWorkspaceService,
+        },
+        {
+          provide: RataRunChecksService,
+          useFactory: () => ({
+            runChecks: jest.fn(),
+          }),
         },
       ],
     }).compile();

--- a/src/rata-run-workspace/rata-run-workspace.service.spec.ts
+++ b/src/rata-run-workspace/rata-run-workspace.service.spec.ts
@@ -13,7 +13,7 @@ import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summ
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { RataRunRepository } from '../rata-run/rata-run.repository';
 import { FlowRataRunWorkspaceService } from '../flow-rata-run-workspace/flow-rata-run-workspace.service';
-import { FlowRataRunDTO } from '../dto/flow-rata-run.dto';
+import { FlowRataRunDTO, FlowRataRunImportDTO } from '../dto/flow-rata-run.dto';
 
 const rataRunId = 'a1b2c3';
 const testSumId = 'd4e5f6';
@@ -75,7 +75,6 @@ describe('RataRunWorkspaceService', () => {
       providers: [
         Logger,
         RataRunWorkspaceService,
-        RataRunMap,
         {
           provide: RataRunWorkspaceRepository,
           useFactory: mockRepository,
@@ -232,6 +231,7 @@ describe('RataRunWorkspaceService', () => {
     });
 
     it('Should import Rata with historical data', async () => {
+      importPayload.flowRataRunData = [new FlowRataRunImportDTO()];
       jest.spyOn(service, 'createRataRun').mockResolvedValue(rataRunDTO);
       jest
         .spyOn(officialRepository, 'findOne')

--- a/src/rata-run-workspace/rata-run-workspace.service.ts
+++ b/src/rata-run-workspace/rata-run-workspace.service.ts
@@ -153,6 +153,7 @@ export class RataRunWorkspaceService {
     isHistoricalRecord?: boolean,
   ) {
     const isImport = true;
+    const promises = [];
     let historicalRecord: RataRun;
 
     if (isHistoricalRecord) {
@@ -174,6 +175,29 @@ export class RataRunWorkspaceService {
     this.logger.info(
       `Rata Run Successfully Imported. Record Id: ${createdRataRun.id}`,
     );
+
+    if (payload.flowRataRunData?.length > 0) {
+      for (const flowRataRun of payload.flowRataRunData) {
+        promises.push(
+          new Promise(async (resolve, _reject) => {
+            const innerPromises = [];
+            innerPromises.push(
+              this.flowRataRunService.import(
+                testSumId,
+                createdRataRun.id,
+                flowRataRun,
+                userId,
+                isHistoricalRecord,
+              ),
+            );
+            await Promise.all(innerPromises);
+            resolve(true);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(promises);
 
     return null;
   }

--- a/src/rata-traverse-workspace/rata-traverse-workspace.controller.spec.ts
+++ b/src/rata-traverse-workspace/rata-traverse-workspace.controller.spec.ts
@@ -8,7 +8,12 @@ describe('RataTraverseWorkspaceController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RataTraverseWorkspaceController],
-      providers: [RataTraverseWorkspaceService],
+      providers: [
+        {
+          provide: RataTraverseWorkspaceService,
+          useFactory: () => ({}),
+        },
+      ],
     }).compile();
 
     controller = module.get<RataTraverseWorkspaceController>(

--- a/src/rata-traverse-workspace/rata-traverse-workspace.module.ts
+++ b/src/rata-traverse-workspace/rata-traverse-workspace.module.ts
@@ -6,10 +6,12 @@ import { RataTraverseWorkspaceRepository } from './rata-traverse-workspace.repos
 import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
 import { FlowRataRunWorkspaceModule } from '../flow-rata-run-workspace/flow-rata-run-workspace.module';
 import { RataTraverseMap } from '../maps/rata-traverse.map';
+import { RataTraverseModule } from '../rata-traverse/rata-traverse.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([RataTraverseWorkspaceRepository]),
+    forwardRef(() => RataTraverseModule),
     forwardRef(() => TestSummaryWorkspaceModule),
     forwardRef(() => FlowRataRunWorkspaceModule),
   ],

--- a/src/rata-traverse/rata-traverse.controller.spec.ts
+++ b/src/rata-traverse/rata-traverse.controller.spec.ts
@@ -8,7 +8,12 @@ describe('RataTraverseController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RataTraverseController],
-      providers: [RataTraverseService],
+      providers: [
+        {
+          provide: RataTraverseService,
+          useFactory: () => ({}),
+        },
+      ],
     }).compile();
 
     controller = module.get<RataTraverseController>(RataTraverseController);

--- a/src/test-qualification-workspace/test-qualification-workspace.service.spec.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.service.spec.ts
@@ -159,6 +159,7 @@ describe('TestQualificationWorkspaceService', () => {
     it('should update a test qualification record', async () => {
       const result = await service.updateTestQualification(
         testSumId,
+        'testQualId',
         payload,
         userId,
       );
@@ -170,7 +171,12 @@ describe('TestQualificationWorkspaceService', () => {
 
       let errored = false;
       try {
-        await service.updateTestQualification(testSumId, payload, userId);
+        await service.updateTestQualification(
+          testSumId,
+          'testQualId',
+          payload,
+          userId,
+        );
       } catch (e) {
         errored = true;
       }


### PR DESCRIPTION
## [Feature/4142: Add Traverse Data elements to Import Endpoint](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/4142)