### PR TITLE
Feature/3024: POST API Endpoint - Add Fuel Flow To Load Test Data

### DIFF
--- a/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
+++ b/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
@@ -72,7 +72,11 @@ export class AirEmissionTestingWorkspaceController {
     @Body() payload: AirEmissionTestingBaseDTO,
     @User() user: CurrentUser,
   ): Promise<AirEmissionTestingRecordDTO> {
-    return this.service.createAirEmissionTesting(testSumId, payload, user.userId);
+    return this.service.createAirEmissionTesting(
+      testSumId,
+      payload,
+      user.userId,
+    );
   }
 
   @Put(':id')

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -34,6 +34,8 @@ import { FlowRataRunModule } from './flow-rata-run/flow-rata-run.module';
 import { FlowRataRunWorkspaceModule } from './flow-rata-run-workspace/flow-rata-run-workspace.module';
 import { RataTraverseWorkspaceModule } from './rata-traverse-workspace/rata-traverse-workspace.module';
 import { RataTraverseModule } from './rata-traverse/rata-traverse.module';
+import { FuelFlowToLoadTestModule } from './fuel-flow-to-load-test/fuel-flow-to-load-test.module';
+import { FuelFlowToLoadTestWorkspaceModule } from './fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module';
 
 @Module({
   imports: [
@@ -69,6 +71,8 @@ import { RataTraverseModule } from './rata-traverse/rata-traverse.module';
     AirEmissionTestingModule,
     RataTraverseWorkspaceModule,
     RataTraverseModule,
+    FuelFlowToLoadTestModule,
+    FuelFlowToLoadTestWorkspaceModule,
   ],
 })
 export class AppModule {}

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -43,16 +43,15 @@ export default registerAs('app', () => ({
   version: process.env.EASEY_QA_CERTIFICATION_API_VERSION || 'v0.0.0',
   published: process.env.EASEY_QA_CERTIFICATION_API_PUBLISHED || 'local',
   authApi: {
-    uri: process.env.EASEY_AUTH_API || 'https://api.epa.gov/easey/dev/auth-mgmt',
+    uri:
+      process.env.EASEY_AUTH_API || 'https://api.epa.gov/easey/dev/auth-mgmt',
   },
   reqSizeLimit: process.env.EASEY_QA_CERTIFICATION_API_REQ_SIZE_LIMIT || '1mb',
   enableSecretToken: parseBool(
     process.env.EASEY_QA_CERTIFICATION_API_ENABLE_SECRET_TOKEN,
   ),
   // ENABLES DEBUG CONSOLE LOGS
-  enableDebug: parseBool(
-    process.env.EASEY_QA_CERTIFICATION_API_ENABLE_DEBUG,
-  ),
+  enableDebug: parseBool(process.env.EASEY_QA_CERTIFICATION_API_ENABLE_DEBUG),
   // NEEDS TO BE SET IN .ENV FILE FOR LOCAL DEVELOPMENT
   // FORMAT: { "userId": "", "roles": [ { "orisCode": 3, "role": "P" } ] }
   currentUser: process.env.EASEY_QA_CERTIFICATION_API_CURRENT_USER,

--- a/src/dto/fuel-flow-to-load-test.dto.ts
+++ b/src/dto/fuel-flow-to-load-test.dto.ts
@@ -1,6 +1,21 @@
-export class FuelFlowToLoadTestBaseDTO {}
+const KEY = 'Fuel Flow To Load Test';
 
-export class FuelFlowToLoadTestRecordDTO extends FuelFlowToLoadTestBaseDTO {}
+export class FuelFlowToLoadTestBaseDTO {
+  testBasisCode: string;
+  averageDifference: number;
+  numberOfHoursUsed: number;
+  numberOfHoursExcludedCofiring: number;
+  numberOfHoursExcludedRamping: number;
+  numberOfHoursExcludedLowRange: number;
+}
+
+export class FuelFlowToLoadTestRecordDTO extends FuelFlowToLoadTestBaseDTO {
+  id: string;
+  testSumId: string;
+  userId: string;
+  addDate: string;
+  updateDate: string;
+}
 
 export class FuelFlowToLoadTestImportDTO extends FuelFlowToLoadTestBaseDTO {}
 

--- a/src/entities/fuel-flow-to-load-test.entity.ts
+++ b/src/entities/fuel-flow-to-load-test.entity.ts
@@ -1,0 +1,80 @@
+import {
+  BaseEntity,
+  Entity,
+  Column,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+
+import { TestSummary } from './test-summary.entity';
+
+@Entity({ name: 'camdecmps.fuel_flow_to_load_check' })
+export class FuelFlowToLoadTest extends BaseEntity {
+  @PrimaryColumn({
+    name: 'fuel_flow_load_id',
+  })
+  id: string;
+
+  @Column({
+    name: 'test_sum_id',
+  })
+  testSumId: string;
+
+  @Column({
+    name: 'test_basis_cd',
+  })
+  testBasisCode: string;
+
+  @Column({
+    name: 'avg_diff',
+    transformer: new NumericColumnTransformer(),
+  })
+  averageDifference: number;
+
+  @Column({
+    name: 'num_hrs',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursUsed: number;
+
+  @Column({
+    name: 'nhe_cofiring',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedCofiring: number;
+
+  @Column({
+    name: 'nhe_ramping',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedRamping: number;
+
+  @Column({
+    name: 'nhe_low_range',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedLowRange: number;
+
+  @Column({ name: 'userid' })
+  userId: string;
+
+  @Column({
+    name: 'add_date',
+  })
+  addDate: Date;
+
+  @Column({
+    name: 'update_date',
+  })
+  updateDate: Date;
+
+  @ManyToOne(
+    () => TestSummary,
+    o => o.fuelFlowToLoadTests,
+  )
+  @JoinColumn({ name: 'test_sum_id' })
+  testSummary: TestSummary;
+}

--- a/src/entities/test-summary.entity.ts
+++ b/src/entities/test-summary.entity.ts
@@ -19,6 +19,7 @@ import { ProtocolGas } from './protocol-gas.entity';
 import { Rata } from './rata.entity';
 import { TestQualification } from './test-qualification.entity';
 import { AirEmissionTesting } from './air-emission-test.entity';
+import { FuelFlowToLoadTest } from './fuel-flow-to-load-test.entity';
 
 @Entity({ name: 'camdecmps.test_summary' })
 export class TestSummary extends BaseEntity {
@@ -213,6 +214,13 @@ export class TestSummary extends BaseEntity {
   )
   @JoinColumn({ name: 'test_sum_id' })
   testQualifications: TestQualification[];
+
+  @OneToMany(
+    () => FuelFlowToLoadTest,
+    o => o.testSummary,
+  )
+  @JoinColumn({ name: 'test_sum_id' })
+  fuelFlowToLoadTests: FuelFlowToLoadTest[];
 
   @OneToMany(
     () => ProtocolGas,

--- a/src/entities/workspace/fuel-flow-to-load-test.entity.ts
+++ b/src/entities/workspace/fuel-flow-to-load-test.entity.ts
@@ -1,0 +1,80 @@
+import {
+  BaseEntity,
+  Entity,
+  Column,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+
+import { TestSummary } from './test-summary.entity';
+
+@Entity({ name: 'camdecmpswks.fuel_flow_to_load_check' })
+export class FuelFlowToLoadTest extends BaseEntity {
+  @PrimaryColumn({
+    name: 'fuel_flow_load_id',
+  })
+  id: string;
+
+  @Column({
+    name: 'test_sum_id',
+  })
+  testSumId: string;
+
+  @Column({
+    name: 'test_basis_cd',
+  })
+  testBasisCode: string;
+
+  @Column({
+    name: 'avg_diff',
+    transformer: new NumericColumnTransformer(),
+  })
+  averageDifference: number;
+
+  @Column({
+    name: 'num_hrs',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursUsed: number;
+
+  @Column({
+    name: 'nhe_cofiring',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedCofiring: number;
+
+  @Column({
+    name: 'nhe_ramping',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedRamping: number;
+
+  @Column({
+    name: 'nhe_low_range',
+    transformer: new NumericColumnTransformer(),
+  })
+  numberOfHoursExcludedLowRange: number;
+
+  @Column({ name: 'userid' })
+  userId: string;
+
+  @Column({
+    name: 'add_date',
+  })
+  addDate: Date;
+
+  @Column({
+    name: 'update_date',
+  })
+  updateDate: Date;
+
+  @ManyToOne(
+    () => TestSummary,
+    o => o.fuelFlowToLoadTests,
+  )
+  @JoinColumn({ name: 'test_sum_id' })
+  testSummary: TestSummary;
+}

--- a/src/entities/workspace/test-summary.entity.ts
+++ b/src/entities/workspace/test-summary.entity.ts
@@ -19,6 +19,7 @@ import { ProtocolGas } from './protocol-gas.entity';
 import { Rata } from './rata.entity';
 import { TestQualification } from './test-qualification.entity';
 import { AirEmissionTesting } from './air-emission-test.entity';
+import { FuelFlowToLoadTest } from './fuel-flow-to-load-test.entity';
 
 @Entity({ name: 'camdecmpswks.test_summary' })
 export class TestSummary extends BaseEntity {
@@ -230,6 +231,13 @@ export class TestSummary extends BaseEntity {
   )
   @JoinColumn({ name: 'test_sum_id' })
   testQualifications: TestQualification[];
+
+  @OneToMany(
+    () => FuelFlowToLoadTest,
+    o => o.testSummary,
+  )
+  @JoinColumn({ name: 'test_sum_id' })
+  fuelFlowToLoadTests: FuelFlowToLoadTest[];
 
   @ManyToOne(
     () => ReportingPeriod,

--- a/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
@@ -129,6 +129,10 @@ export class FlowRataRunWorkspaceController {
     @Param('id') flowRataRunId: string,
     @User() user: CurrentUser,
   ): Promise<void> {
-    return this.service.deleteFlowRataRun(testSumId, flowRataRunId, user.userId);
+    return this.service.deleteFlowRataRun(
+      testSumId,
+      flowRataRunId,
+      user.userId,
+    );
   }
 }

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
@@ -1,14 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  FuelFlowToLoadTestBaseDTO,
+  FuelFlowToLoadTestDTO,
+} from '../dto/fuel-flow-to-load-test.dto';
 import { FuelFlowToLoadTestWorkspaceController } from './fuel-flow-to-load-test-workspace.controller';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
 
+const locId = '';
+const testSumId = '';
+const testQualificationId = 'g7h8i9';
+const testUser = 'testUser';
+
+const fuelFlowToLoadTest = new FuelFlowToLoadTestDTO();
+const fuelFlowToLoadTests = [fuelFlowToLoadTest];
+
+const mockService = () => ({
+  createFuelFlowToLoadTest: jest.fn().mockResolvedValue(fuelFlowToLoadTest),
+});
+
+const payload = new FuelFlowToLoadTestBaseDTO();
+
 describe('FuelFlowToLoadTestWorkspaceController', () => {
   let controller: FuelFlowToLoadTestWorkspaceController;
+  let service: FuelFlowToLoadTestWorkspaceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FuelFlowToLoadTestWorkspaceController],
-      providers: [FuelFlowToLoadTestWorkspaceService],
+      providers: [
+        {
+          provide: FuelFlowToLoadTestWorkspaceService,
+          useFactory: mockService,
+        },
+      ],
     }).compile();
 
     controller = module.get<FuelFlowToLoadTestWorkspaceController>(
@@ -16,7 +40,14 @@ describe('FuelFlowToLoadTestWorkspaceController', () => {
     );
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('createFuelFlowToLoadTest', () => {
+    it('Calls the service to create a new fuel Flow To Load Test record', async () => {
+      const result = await controller.createFuelFlowToLoadTest(
+        locId,
+        testSumId,
+        payload,
+      );
+      expect(result).toEqual(fuelFlowToLoadTest);
+    });
   });
 });

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
@@ -1,4 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule } from '@nestjs/axios';
+import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { ConfigService } from '@nestjs/config';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import {
   FuelFlowToLoadTestBaseDTO,
   FuelFlowToLoadTestDTO,
@@ -8,8 +12,14 @@ import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-wor
 
 const locId = '';
 const testSumId = '';
-const testQualificationId = 'g7h8i9';
-const testUser = 'testUser';
+const user: CurrentUser = {
+  userId: 'testUser',
+  sessionId: '',
+  expiration: '',
+  clientIp: '',
+  isAdmin: false,
+  roles: [],
+};
 
 const fuelFlowToLoadTest = new FuelFlowToLoadTestDTO();
 const fuelFlowToLoadTests = [fuelFlowToLoadTest];
@@ -22,12 +32,14 @@ const payload = new FuelFlowToLoadTestBaseDTO();
 
 describe('FuelFlowToLoadTestWorkspaceController', () => {
   let controller: FuelFlowToLoadTestWorkspaceController;
-  let service: FuelFlowToLoadTestWorkspaceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       controllers: [FuelFlowToLoadTestWorkspaceController],
       providers: [
+        ConfigService,
+        AuthGuard,
         {
           provide: FuelFlowToLoadTestWorkspaceService,
           useFactory: mockService,
@@ -46,6 +58,7 @@ describe('FuelFlowToLoadTestWorkspaceController', () => {
         locId,
         testSumId,
         payload,
+        user,
       );
       expect(result).toEqual(fuelFlowToLoadTest);
     });

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuelFlowToLoadTestWorkspaceController } from './fuel-flow-to-load-test-workspace.controller';
+import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+
+describe('FuelFlowToLoadTestWorkspaceController', () => {
+  let controller: FuelFlowToLoadTestWorkspaceController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FuelFlowToLoadTestWorkspaceController],
+      providers: [FuelFlowToLoadTestWorkspaceService],
+    }).compile();
+
+    controller = module.get<FuelFlowToLoadTestWorkspaceController>(
+      FuelFlowToLoadTestWorkspaceController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Param, Post } from '@nestjs/common';
+import { ApiCreatedResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import {
+  FuelFlowToLoadTestBaseDTO,
+  FuelFlowToLoadTestRecordDTO,
+} from 'src/dto/fuel-flow-to-load-test.dto';
+import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+
+const userId = 'testUser';
+
+@Controller()
+@ApiSecurity('APIKey')
+@ApiTags('Fuel Flow To Load Test')
+export class FuelFlowToLoadTestWorkspaceController {
+  constructor(private readonly service: FuelFlowToLoadTestWorkspaceService) {}
+
+  @Post()
+  //  @ApiBearerAuth('Token')
+  //  @UseGuards(AuthGuard)
+  @ApiCreatedResponse({
+    type: FuelFlowToLoadTestRecordDTO,
+    description: 'Creates a workspace Fuel Flow To Load Test record.',
+  })
+  async createFuelFlowToLoadTest(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Body() payload: FuelFlowToLoadTestBaseDTO,
+    //    @CurrentUser() userId: string,
+  ): Promise<FuelFlowToLoadTestRecordDTO> {
+    return this.service.createFuelFlowToLoadTest(testSumId, payload, userId);
+  }
+}

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
@@ -1,12 +1,18 @@
-import { Body, Controller, Param, Post } from '@nestjs/common';
-import { ApiCreatedResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { User } from '@us-epa-camd/easey-common/decorators';
+import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import {
   FuelFlowToLoadTestBaseDTO,
   FuelFlowToLoadTestRecordDTO,
 } from '../dto/fuel-flow-to-load-test.dto';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
-
-const userId = 'testUser';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -15,8 +21,8 @@ export class FuelFlowToLoadTestWorkspaceController {
   constructor(private readonly service: FuelFlowToLoadTestWorkspaceService) {}
 
   @Post()
-  //  @ApiBearerAuth('Token')
-  //  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @UseGuards(AuthGuard)
   @ApiCreatedResponse({
     type: FuelFlowToLoadTestRecordDTO,
     description: 'Creates a workspace Fuel Flow To Load Test record.',
@@ -25,8 +31,12 @@ export class FuelFlowToLoadTestWorkspaceController {
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
     @Body() payload: FuelFlowToLoadTestBaseDTO,
-    //    @CurrentUser() userId: string,
+    @User() user: CurrentUser,
   ): Promise<FuelFlowToLoadTestRecordDTO> {
-    return this.service.createFuelFlowToLoadTest(testSumId, payload, userId);
+    return this.service.createFuelFlowToLoadTest(
+      testSumId,
+      payload,
+      user.userId,
+    );
   }
 }

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
@@ -3,7 +3,7 @@ import { ApiCreatedResponse, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import {
   FuelFlowToLoadTestBaseDTO,
   FuelFlowToLoadTestRecordDTO,
-} from 'src/dto/fuel-flow-to-load-test.dto';
+} from '../dto/fuel-flow-to-load-test.dto';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
 
 const userId = 'testUser';

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
@@ -5,8 +5,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FuelFlowToLoadTestWorkspaceRepository } from './fuel-flow-to-load-test-workspace.repository';
 import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
 import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
-import { TestQualificationMap } from '../maps/test-qualification.map';
-import { TestQualificationWorkspaceService } from '../test-qualification-workspace/test-qualification-workspace.service';
 
 @Module({
   imports: [

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
@@ -1,0 +1,24 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+import { FuelFlowToLoadTestWorkspaceController } from './fuel-flow-to-load-test-workspace.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FuelFlowToLoadTestWorkspaceRepository } from './fuel-flow-to-load-test-workspace.repository';
+import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
+import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
+import { TestQualificationMap } from '../maps/test-qualification.map';
+import { TestQualificationWorkspaceService } from '../test-qualification-workspace/test-qualification-workspace.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FuelFlowToLoadTestWorkspaceRepository]),
+    forwardRef(() => TestSummaryWorkspaceModule),
+  ],
+  controllers: [FuelFlowToLoadTestWorkspaceController],
+  providers: [FuelFlowToLoadTestMap, FuelFlowToLoadTestWorkspaceService],
+  exports: [
+    TypeOrmModule,
+    FuelFlowToLoadTestMap,
+    FuelFlowToLoadTestWorkspaceService,
+  ],
+})
+export class FuelFlowToLoadTestWorkspaceModule {}

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module.ts
@@ -1,3 +1,4 @@
+import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
 import { FuelFlowToLoadTestWorkspaceController } from './fuel-flow-to-load-test-workspace.controller';
@@ -10,6 +11,7 @@ import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
   imports: [
     TypeOrmModule.forFeature([FuelFlowToLoadTestWorkspaceRepository]),
     forwardRef(() => TestSummaryWorkspaceModule),
+    HttpModule,
   ],
   controllers: [FuelFlowToLoadTestWorkspaceController],
   providers: [FuelFlowToLoadTestMap, FuelFlowToLoadTestWorkspaceService],

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.repository.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.repository.ts
@@ -1,0 +1,7 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { FuelFlowToLoadTest } from '../entities/workspace/fuel-flow-to-load-test.entity';
+
+@EntityRepository(FuelFlowToLoadTest)
+export class FuelFlowToLoadTestWorkspaceRepository extends Repository<
+  FuelFlowToLoadTest
+> {}

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.spec.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.spec.ts
@@ -1,20 +1,84 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  FuelFlowToLoadTestBaseDTO,
+  FuelFlowToLoadTestDTO,
+} from '../dto/fuel-flow-to-load-test.dto';
+import { FuelFlowToLoadTest } from '../entities/fuel-flow-to-load-test.entity';
+import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
+import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
+import { FuelFlowToLoadTestWorkspaceRepository } from './fuel-flow-to-load-test-workspace.repository';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+
+const testSumId = '';
+const userId = 'user';
+const entity = new FuelFlowToLoadTest();
+const fuelFlowToLoadTestRecord = new FuelFlowToLoadTestDTO();
+const fuelFlowToLoadTests = [fuelFlowToLoadTestRecord];
+
+const payload = new FuelFlowToLoadTestBaseDTO();
+
+const mockRepository = () => ({
+  find: jest.fn().mockResolvedValue([entity]),
+  findOne: jest.fn().mockResolvedValue(entity),
+  save: jest.fn().mockResolvedValue(entity),
+  create: jest.fn().mockResolvedValue(entity),
+  delete: jest.fn().mockResolvedValue(null),
+});
+
+const mockMap = () => ({
+  one: jest.fn().mockResolvedValue(fuelFlowToLoadTestRecord),
+  many: jest.fn().mockResolvedValue(fuelFlowToLoadTests),
+});
+
+const mockTestSumService = () => ({
+  resetToNeedsEvaluation: jest.fn(),
+});
 
 describe('FuelFlowToLoadTestWorkspaceService', () => {
   let service: FuelFlowToLoadTestWorkspaceService;
+  let testSummaryService: TestSummaryWorkspaceService;
+  let repository: FuelFlowToLoadTestWorkspaceRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FuelFlowToLoadTestWorkspaceService],
+      providers: [
+        FuelFlowToLoadTestWorkspaceService,
+        {
+          provide: TestSummaryWorkspaceService,
+          useFactory: mockTestSumService,
+        },
+        {
+          provide: FuelFlowToLoadTestWorkspaceRepository,
+          useFactory: mockRepository,
+        },
+        {
+          provide: FuelFlowToLoadTestMap,
+          useFactory: mockMap,
+        },
+      ],
     }).compile();
 
     service = module.get<FuelFlowToLoadTestWorkspaceService>(
       FuelFlowToLoadTestWorkspaceService,
     );
+    testSummaryService = module.get<TestSummaryWorkspaceService>(
+      TestSummaryWorkspaceService,
+    );
+    repository = module.get<FuelFlowToLoadTestWorkspaceRepository>(
+      FuelFlowToLoadTestWorkspaceRepository,
+    );
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('createFuelFlowToLoadTest', () => {
+    it('Should create and return a new Fuel Flow To Load Test record', async () => {
+      const result = await service.createFuelFlowToLoadTest(
+        testSumId,
+        payload,
+        userId,
+      );
+
+      expect(result).toEqual(fuelFlowToLoadTestRecord);
+      expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
+    });
   });
 });

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.spec.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+
+describe('FuelFlowToLoadTestWorkspaceService', () => {
+  let service: FuelFlowToLoadTestWorkspaceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FuelFlowToLoadTestWorkspaceService],
+    }).compile();
+
+    service = module.get<FuelFlowToLoadTestWorkspaceService>(
+      FuelFlowToLoadTestWorkspaceService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
@@ -3,9 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import {
   FuelFlowToLoadTestBaseDTO,
   FuelFlowToLoadTestRecordDTO,
-} from 'src/dto/fuel-flow-to-load-test.dto';
-import { FuelFlowToLoadTestMap } from 'src/maps/fuel-flow-to-load-test.map';
-import { TestSummaryWorkspaceService } from 'src/test-summary-workspace/test-summary.service';
+} from '../dto/fuel-flow-to-load-test.dto';
+import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
+import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { FuelFlowToLoadTestWorkspaceRepository } from './fuel-flow-to-load-test-workspace.repository';
 import { currentDateTime } from '../utilities/functions';
 import { v4 as uuid } from 'uuid';

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
@@ -1,0 +1,49 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  FuelFlowToLoadTestBaseDTO,
+  FuelFlowToLoadTestRecordDTO,
+} from 'src/dto/fuel-flow-to-load-test.dto';
+import { FuelFlowToLoadTestMap } from 'src/maps/fuel-flow-to-load-test.map';
+import { TestSummaryWorkspaceService } from 'src/test-summary-workspace/test-summary.service';
+import { FuelFlowToLoadTestWorkspaceRepository } from './fuel-flow-to-load-test-workspace.repository';
+import { currentDateTime } from '../utilities/functions';
+import { v4 as uuid } from 'uuid';
+
+@Injectable()
+export class FuelFlowToLoadTestWorkspaceService {
+  constructor(
+    private readonly map: FuelFlowToLoadTestMap,
+    @Inject(forwardRef(() => TestSummaryWorkspaceService))
+    private readonly testSummaryService: TestSummaryWorkspaceService,
+    @InjectRepository(FuelFlowToLoadTestWorkspaceRepository)
+    private readonly repository: FuelFlowToLoadTestWorkspaceRepository,
+  ) {}
+
+  async createFuelFlowToLoadTest(
+    testSumId: string,
+    payload: FuelFlowToLoadTestBaseDTO,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<FuelFlowToLoadTestRecordDTO> {
+    const timestamp = currentDateTime();
+
+    let entity = this.repository.create({
+      ...payload,
+      id: uuid(),
+      testSumId,
+      userId,
+      addDate: timestamp,
+      updateDate: timestamp,
+    });
+
+    await this.repository.save(entity);
+    entity = await this.repository.findOne(entity.id);
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+    return this.map.one(entity);
+  }
+}

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.spec.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuelFlowToLoadTestController } from './fuel-flow-to-load-test.controller';
+import { FuelFlowToLoadTestService } from './fuel-flow-to-load-test.service';
+
+describe('FuelFlowToLoadTestController', () => {
+  let controller: FuelFlowToLoadTestController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FuelFlowToLoadTestController],
+      providers: [FuelFlowToLoadTestService],
+    }).compile();
+
+    controller = module.get<FuelFlowToLoadTestController>(
+      FuelFlowToLoadTestController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { FuelFlowToLoadTestService } from './fuel-flow-to-load-test.service';
+
+@Controller('fuel-flow-to-load-test')
+export class FuelFlowToLoadTestController {
+  constructor(
+    private readonly fuelFlowToLoadTestService: FuelFlowToLoadTestService,
+  ) {}
+}

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.controller.ts
@@ -1,9 +1,10 @@
 import { Controller } from '@nestjs/common';
+import { ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { FuelFlowToLoadTestService } from './fuel-flow-to-load-test.service';
 
-@Controller('fuel-flow-to-load-test')
+@Controller()
+@ApiSecurity('APIKey')
+@ApiTags('Fuel Flow To Load Test')
 export class FuelFlowToLoadTestController {
-  constructor(
-    private readonly fuelFlowToLoadTestService: FuelFlowToLoadTestService,
-  ) {}
+  constructor(private readonly service: FuelFlowToLoadTestService) {}
 }

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.module.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.module.ts
@@ -5,8 +5,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FuelFlowToLoadTestRepository } from './fuel-flow-to-load-test.repository';
 import { TestSummaryModule } from '../test-summary/test-summary.module';
 import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
-import { TestQualificationService } from '../test-qualification/test-qualification.service';
-import { TestQualificationMap } from '../maps/test-qualification.map';
 
 @Module({
   imports: [

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.module.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.module.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { FuelFlowToLoadTestService } from './fuel-flow-to-load-test.service';
+import { FuelFlowToLoadTestController } from './fuel-flow-to-load-test.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FuelFlowToLoadTestRepository } from './fuel-flow-to-load-test.repository';
+import { TestSummaryModule } from '../test-summary/test-summary.module';
+import { FuelFlowToLoadTestMap } from '../maps/fuel-flow-to-load-test.map';
+import { TestQualificationService } from '../test-qualification/test-qualification.service';
+import { TestQualificationMap } from '../maps/test-qualification.map';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FuelFlowToLoadTestRepository]),
+    forwardRef(() => TestSummaryModule),
+  ],
+  controllers: [FuelFlowToLoadTestController],
+  providers: [FuelFlowToLoadTestMap, FuelFlowToLoadTestService],
+  exports: [TypeOrmModule, FuelFlowToLoadTestMap, FuelFlowToLoadTestService],
+})
+export class FuelFlowToLoadTestModule {}

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.repository.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.repository.ts
@@ -1,0 +1,7 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { FuelFlowToLoadTest } from '../entities/fuel-flow-to-load-test.entity';
+
+@EntityRepository(FuelFlowToLoadTest)
+export class FuelFlowToLoadTestRepository extends Repository<
+  FuelFlowToLoadTest
+> {}

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.service.spec.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FuelFlowToLoadTestService } from './fuel-flow-to-load-test.service';
+
+describe('FuelFlowToLoadTestService', () => {
+  let service: FuelFlowToLoadTestService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FuelFlowToLoadTestService],
+    }).compile();
+
+    service = module.get<FuelFlowToLoadTestService>(FuelFlowToLoadTestService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/fuel-flow-to-load-test/fuel-flow-to-load-test.service.ts
+++ b/src/fuel-flow-to-load-test/fuel-flow-to-load-test.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FuelFlowToLoadTestService {}

--- a/src/linearity-injection-workspace/linearity-injection.controller.ts
+++ b/src/linearity-injection-workspace/linearity-injection.controller.ts
@@ -82,7 +82,12 @@ export class LinearityInjectionWorkspaceController {
     @User() user: CurrentUser,
   ): Promise<LinearityInjectionRecordDTO> {
     await this.checksService.runChecks(linSumId, payload);
-    return this.service.createInjection(testSumId, linSumId, payload, user.userId);
+    return this.service.createInjection(
+      testSumId,
+      linSumId,
+      payload,
+      user.userId,
+    );
   }
 
   @Put(':id')

--- a/src/maps/fuel-flow-to-load-test.map.ts
+++ b/src/maps/fuel-flow-to-load-test.map.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { BaseMap } from '@us-epa-camd/easey-common/maps';
+import { FuelFlowToLoadTestDTO } from '../dto/fuel-flow-to-load-test.dto';
+import { FuelFlowToLoadTest } from '../entities/fuel-flow-to-load-test.entity';
+
+@Injectable()
+export class FuelFlowToLoadTestMap extends BaseMap<
+  FuelFlowToLoadTest,
+  FuelFlowToLoadTestDTO
+> {
+  public async one(entity: FuelFlowToLoadTest): Promise<FuelFlowToLoadTestDTO> {
+    return {
+      id: entity.id,
+      testSumId: entity.testSumId,
+      testBasisCode: entity.testBasisCode,
+      averageDifference: entity.averageDifference,
+      numberOfHoursUsed: entity.numberOfHoursUsed,
+      numberOfHoursExcludedCofiring: entity.numberOfHoursExcludedCofiring,
+      numberOfHoursExcludedRamping: entity.numberOfHoursExcludedRamping,
+      numberOfHoursExcludedLowRange: entity.numberOfHoursExcludedLowRange,
+      userId: entity.userId,
+      addDate: entity.addDate ? entity.addDate.toLocaleString() : null,
+      updateDate: entity.updateDate ? entity.updateDate.toLocaleString() : null,
+    };
+  }
+}

--- a/src/maps/test-summary.map.ts
+++ b/src/maps/test-summary.map.ts
@@ -9,6 +9,7 @@ import { ProtocolGasMap } from './protocol-gas.map';
 import { RataMap } from './rata.map';
 import { TestQualificationMap } from './test-qualification.map';
 import { AirEmissionTestingMap } from './air-emission-testing.map';
+import { FuelFlowToLoadTestMap } from './fuel-flow-to-load-test.map';
 
 @Injectable()
 export class TestSummaryMap extends BaseMap<TestSummary, TestSummaryDTO> {
@@ -18,6 +19,7 @@ export class TestSummaryMap extends BaseMap<TestSummary, TestSummaryDTO> {
     private readonly airEmissionTestingMap: AirEmissionTestingMap,
     private readonly rataMap: RataMap,
     private readonly testQualificationMap: TestQualificationMap,
+    private readonly fuelFlowToLoadTestMap: FuelFlowToLoadTestMap,
   ) {
     super();
   }
@@ -40,6 +42,10 @@ export class TestSummaryMap extends BaseMap<TestSummary, TestSummaryDTO> {
     const ratas = entity.ratas ? await this.rataMap.many(entity.ratas) : [];
     const testQuals = entity.testQualifications
       ? await this.testQualificationMap.many(entity.testQualifications)
+      : [];
+
+    const fuelFlowToloadTest = entity.fuelFlowToLoadTests
+      ? await this.fuelFlowToLoadTestMap.many(entity.fuelFlowToLoadTests)
       : [];
 
     if (entity['evalStatusCode']) {
@@ -97,7 +103,7 @@ export class TestSummaryMap extends BaseMap<TestSummary, TestSummaryDTO> {
       fuelFlowmeterAccuracyData: [],
       transmitterTransducerData: [],
       fuelFlowToLoadBaselineData: [],
-      fuelFlowToLoadTestData: [],
+      fuelFlowToLoadTestData: fuelFlowToloadTest,
       appECorrelationTestSummaryData: [],
       unitDefaultTestData: [],
       hgSummaryData: [],

--- a/src/protocol-gas-workspace/protocol-gas.service.spec.ts
+++ b/src/protocol-gas-workspace/protocol-gas.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
-import { ProtocolGasBaseDTO, ProtocolGasDTO, ProtocolGasImportDTO } from '../dto/protocol-gas.dto';
+import {
+  ProtocolGasBaseDTO,
+  ProtocolGasDTO,
+  ProtocolGasImportDTO,
+} from '../dto/protocol-gas.dto';
 import { ProtocolGas } from '../entities/workspace/protocol-gas.entity';
 import { ProtocolGasMap } from '../maps/protocol-gas.map';
 import { ProtocolGasWorkspaceRepository } from './protocol-gas.repository';
@@ -127,9 +131,11 @@ describe('ProtocolGasWorkspaceService', () => {
 
   describe('Import', () => {
     it('Should Import Protocol Gas', async () => {
-      jest.spyOn(service, 'createProtocolGas').mockResolvedValue(protocolGasDTO);
+      jest
+        .spyOn(service, 'createProtocolGas')
+        .mockResolvedValue(protocolGasDTO);
 
       await service.import(testSumId, new ProtocolGasImportDTO(), userId, true);
-    })
-  })
+    });
+  });
 });

--- a/src/rata-run-workspace/rata-run-workspace.controller.ts
+++ b/src/rata-run-workspace/rata-run-workspace.controller.ts
@@ -89,7 +89,12 @@ export class RataRunWorkspaceController {
       false,
       true,
     );
-    return this.service.createRataRun(testSumId, rataSumId, payload, user.userId);
+    return this.service.createRataRun(
+      testSumId,
+      rataSumId,
+      payload,
+      user.userId,
+    );
   }
 
   @Delete(':id')

--- a/src/rata-summary-workspace/rata-summary-checks.service.ts
+++ b/src/rata-summary-workspace/rata-summary-checks.service.ts
@@ -63,7 +63,6 @@ export class RataSummaryChecksService {
       if (error) {
         errorList.push(error);
       }
-      
     } else {
       testSumRecord = await this.testSummaryRepository.getTestSummaryById(
         testSumId,

--- a/src/rata-summary-workspace/rata-summary-workspace.controller.ts
+++ b/src/rata-summary-workspace/rata-summary-workspace.controller.ts
@@ -85,7 +85,12 @@ export class RataSummaryWorkspaceController {
       rataId,
       testSumId,
     );
-    return this.service.createRataSummary(testSumId, rataId, payload, user.userId);
+    return this.service.createRataSummary(
+      testSumId,
+      rataId,
+      payload,
+      user.userId,
+    );
   }
 
   @Put(':id')

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -30,6 +30,8 @@ import { FlowRataRunModule } from './flow-rata-run/flow-rata-run.module';
 import { FlowRataRunWorkspaceModule } from './flow-rata-run-workspace/flow-rata-run-workspace.module';
 import { RataTraverseWorkspaceModule } from './rata-traverse-workspace/rata-traverse-workspace.module';
 import { RataTraverseModule } from './rata-traverse/rata-traverse.module';
+import { FuelFlowToLoadTestModule } from './fuel-flow-to-load-test/fuel-flow-to-load-test.module';
+import { FuelFlowToLoadTestWorkspaceModule } from './fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module';
 
 const routes: Routes = [
   {
@@ -65,6 +67,10 @@ const routes: Routes = [
           {
             path: ':testSumId/test-qualifications',
             module: TestQualificationModule,
+          },
+          {
+            path: ':testSumId/fuel-flow-to-load-tests',
+            module: FuelFlowToLoadTestModule,
           },
           {
             path: ':testSumId/air-emission-testings',
@@ -131,6 +137,10 @@ const routes: Routes = [
           {
             path: ':testSumId/test-qualifications',
             module: TestQualificationWorkspaceModule,
+          },
+          {
+            path: ':testSumId/fuel-flow-to-load-tests',
+            module: FuelFlowToLoadTestWorkspaceModule,
           },
           {
             path: ':testSumId/rata',

--- a/src/test-qualification-workspace/test-qualification-workspace.controller.spec.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.controller.spec.ts
@@ -54,10 +54,6 @@ describe('TestQualificationWorkspaceController', () => {
     );
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-
   describe('getTestQualifications', () => {
     it('Calls service to get all Test Qualification records for a given Test Summary ID', async () => {
       const results = await controller.getTestQualifications(locId, testSumId);

--- a/src/test-qualification-workspace/test-qualification-workspace.controller.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.controller.ts
@@ -71,7 +71,11 @@ export class TestQualificationWorkspaceController {
     @Body() payload: TestQualificationBaseDTO,
     @User() user: CurrentUser,
   ): Promise<TestQualificationRecordDTO> {
-    return this.service.createTestQualification(testSumId, payload, user.userId);
+    return this.service.createTestQualification(
+      testSumId,
+      payload,
+      user.userId,
+    );
   }
 
   @Delete(':id')
@@ -107,6 +111,11 @@ export class TestQualificationWorkspaceController {
     @Body() payload: TestQualificationBaseDTO,
     @User() user: CurrentUser,
   ): Promise<TestQualificationRecordDTO> {
-    return this.service.updateTestQualification(testSumId, id, payload, user.userId);
+    return this.service.updateTestQualification(
+      testSumId,
+      id,
+      payload,
+      user.userId,
+    );
   }
 }

--- a/src/test-summary-workspace/test-summary.module.ts
+++ b/src/test-summary-workspace/test-summary.module.ts
@@ -21,6 +21,7 @@ import { MonitorMethodRepository } from '../monitor-method/monitor-method.reposi
 import { TestResultCodeModule } from '../test-result-code/test-result-code.module';
 import { TestQualificationWorkspaceModule } from '../test-qualification-workspace/test-qualification-workspace.module';
 import { AirEmissionTestingWorkspaceModule } from '../air-emission-testing-workspace/air-emission-testing-workspace.module';
+import { FuelFlowToLoadTestWorkspaceModule } from '../fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { AirEmissionTestingWorkspaceModule } from '../air-emission-testing-works
     forwardRef(() => ProtocolGasWorkspaceModule),
     forwardRef(() => RataWorkspaceModule),
     forwardRef(() => TestQualificationWorkspaceModule),
+    forwardRef(() => FuelFlowToLoadTestWorkspaceModule),
     forwardRef(() => AirEmissionTestingWorkspaceModule),
     TestResultCodeModule,
   ],

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -97,7 +97,7 @@ describe('TestSummaryWorkspaceService', () => {
         {
           provide: ProtocolGasWorkspaceService,
           useFactory: mockProtocolGasService,
-        }
+        },
       ],
     }).compile();
 

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -147,7 +147,8 @@ export class TestSummaryWorkspaceService {
     promises.push(
       new Promise(async (resolve, _reject) => {
         let linearitySummaryData,
-          rataData, protocolGasData = null;
+          rataData,
+          protocolGasData = null;
         let testSumIds;
         if (testTypeCodes?.length > 0) {
           testSumIds = testSummaries.filter(i =>
@@ -165,7 +166,9 @@ export class TestSummaryWorkspaceService {
               i => i.testSumId === s.id,
             );
             s.rataData = rataData.filter(i => i.testSumId === s.id);
-            s.protocolGasData = protocolGasData.filter(i => i.testSumId === s.id)
+            s.protocolGasData = protocolGasData.filter(
+              i => i.testSumId === s.id,
+            );
           });
         }
 

--- a/src/test-summary/test-summary.module.ts
+++ b/src/test-summary/test-summary.module.ts
@@ -12,6 +12,7 @@ import { TestSummaryMap } from '../maps/test-summary.map';
 import { RataModule } from '../rata/rata.module';
 import { TestQualificationModule } from '../test-qualification/test-qualification.module';
 import { AirEmissionTestingModule } from '../air-emission-testing/air-emission-testing.module';
+import { FuelFlowToLoadTestModule } from '../fuel-flow-to-load-test/fuel-flow-to-load-test.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { AirEmissionTestingModule } from '../air-emission-testing/air-emission-t
     ProtocolGasModule,
     RataModule,
     TestQualificationModule,
+    FuelFlowToLoadTestModule,
     AirEmissionTestingModule,
   ],
   controllers: [TestSummaryController],

--- a/src/test-summary/test-summary.service.ts
+++ b/src/test-summary/test-summary.service.ts
@@ -121,7 +121,8 @@ export class TestSummaryService {
     promises.push(
       new Promise(async (resolve, _reject) => {
         let linearitySummaryData,
-          rataData, protocolGasData = null;
+          rataData,
+          protocolGasData = null;
         let testSumIds;
         if (testTypeCodes?.length > 0) {
           testSumIds = testSummaries.filter(i =>
@@ -139,7 +140,9 @@ export class TestSummaryService {
               i => i.testSumId === s.id,
             );
             s.rataData = rataData.filter(i => i.testSumId === s.id);
-            s.protocolGasData = protocolGasData.filter(i => i.testSumId === s.id)
+            s.protocolGasData = protocolGasData.filter(
+              i => i.testSumId === s.id,
+            );
           });
         }
 


### PR DESCRIPTION
## [Feature/3024: POST API Endpoint - Add Fuel Flow To Load Test Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3024)