### PR TITLE
Appendix E test summary result code issue

### DIFF
--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -23,6 +23,7 @@ import { TestSummaryMasterDataRelationshipRepository } from '../test-summary-mas
 import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
 import { MonitorMethodRepository } from '../monitor-method/monitor-method.repository';
 import { TestResultCodeRepository } from '../test-result-code/test-result-code.repository';
+import { VALID_TEST_TYPE_CODES_FOR_TEST_RESULT_CODE } from 'src/utilities/constants';
 
 const KEY = 'Test Summary';
 
@@ -166,9 +167,11 @@ export class TestSummaryChecksService {
     }
 
     // RATA-100 Test Result Code Valid
-    error = await this.rata100check(summary);
-    if (error) {
-      errorList.push(error);
+    if (VALID_TEST_TYPE_CODES_FOR_TEST_RESULT_CODE.includes(summary.testResultCode)){
+      error = await this.rata100check(summary);
+      if (error) {
+        errorList.push(error);
+      }
     }
 
     if (!isUpdate) {


### PR DESCRIPTION
Added check to ensure test summaries are allowed to pass null test result codes if required

Ex: "APPE" test type code cannot have a test result code other than null