### PR TITLE
Feature/3129-3128: EDIT and DELETE API Endpoint - Fuel Flow to Load Baseline Data

### DIFF
--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.spec.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.spec.ts
@@ -26,6 +26,7 @@ const dto = new FuelFlowToLoadBaselineDTO();
 const payload = new FuelFlowToLoadBaselineBaseDTO();
 
 const mockService = () => ({
+  updateFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
   createFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
   getFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
   getFuelFlowToLoadBaselines: jest.fn().mockResolvedValue([dto]),
@@ -79,6 +80,19 @@ describe('FuelFlowToLoadBaselineWorkspaceController', () => {
       const result = await controller.createFuelFlowToLoadBaseline(
         locId,
         testSumId,
+        payload,
+        user,
+      );
+      expect(result).toEqual(dto);
+    });
+  });
+
+  describe('updateFuelFlowToLoadBaseline', () => {
+    it('Calls the service and update a existing fuel Flow To Load Baseline record', async () => {
+      const result = await controller.updateFuelFlowToLoadBaseline(
+        locId,
+        testSumId,
+        id,
         payload,
         user,
       );

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.spec.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.spec.ts
@@ -26,6 +26,7 @@ const dto = new FuelFlowToLoadBaselineDTO();
 const payload = new FuelFlowToLoadBaselineBaseDTO();
 
 const mockService = () => ({
+  deleteFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(undefined),
   updateFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
   createFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
   getFuelFlowToLoadBaseline: jest.fn().mockResolvedValue(dto),
@@ -97,6 +98,18 @@ describe('FuelFlowToLoadBaselineWorkspaceController', () => {
         user,
       );
       expect(result).toEqual(dto);
+    });
+  });
+
+  describe('deleteFuelFlowToLoadBaseline', () => {
+    it('Calls the service and delete a fuel Flow To Load Baseline record', async () => {
+      const result = await controller.deleteFuelFlowToLoadBaseline(
+        locId,
+        testSumId,
+        id,
+        user,
+      );
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
@@ -67,6 +75,28 @@ export class FuelFlowToLoadBaselineWorkspaceController {
   ): Promise<FuelFlowToLoadBaselineDTO> {
     return this.service.createFuelFlowToLoadBaseline(
       testSumId,
+      payload,
+      user.userId,
+    );
+  }
+
+  @Put(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    type: FuelFlowToLoadBaselineDTO,
+    description: 'Updates a workspace Fuel Flow To Load Baseline record.',
+  })
+  updateFuelFlowToLoadBaseline(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @Body() payload: FuelFlowToLoadBaselineBaseDTO,
+    @User() user: CurrentUser,
+  ): Promise<FuelFlowToLoadBaselineDTO> {
+    return this.service.updateFuelFlowToLoadBaseline(
+      testSumId,
+      id,
       payload,
       user.userId,
     );

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -98,6 +99,25 @@ export class FuelFlowToLoadBaselineWorkspaceController {
       testSumId,
       id,
       payload,
+      user.userId,
+    );
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    description: 'Deletes a Linearity Summary record from the workspace',
+  })
+  async deleteFuelFlowToLoadBaseline(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @User() user: CurrentUser,
+  ): Promise<void> {
+    return this.service.deleteFuelFlowToLoadBaseline(
+      testSumId,
+      id,
       user.userId,
     );
   }

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
@@ -110,4 +110,36 @@ describe('FuelFlowToLoadBaselineWorkspaceService', () => {
       expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
     });
   });
+
+  describe('updateFuelFlowToLoadBaseline', () => {
+    it('Should update and return a new Fuel Flow To Load Baseline record', async () => {
+      const result = await service.updateFuelFlowToLoadBaseline(
+        testSumId,
+        id,
+        payload,
+        userId,
+      );
+
+      expect(result).toEqual(dto);
+      expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
+    });
+
+    it('Should throw error when a Fuel Flow To Load Baseline record not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(undefined);
+      let errored = false;
+
+      try {
+        await service.updateFuelFlowToLoadBaseline(
+          testSumId,
+          id,
+          payload,
+          userId,
+        );
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+    });
+  });
 });

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
@@ -1,4 +1,6 @@
+import { HttpStatus, InternalServerErrorException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
 import {
   FuelFlowToLoadBaselineBaseDTO,
   FuelFlowToLoadBaselineDTO,
@@ -135,6 +137,34 @@ describe('FuelFlowToLoadBaselineWorkspaceService', () => {
           payload,
           userId,
         );
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+    });
+  });
+
+  describe('deleteFuelFlowToLoadBaseline', () => {
+    it('Should delete a Fuel Flow To Load Baseline record', async () => {
+      const result = await service.deleteFuelFlowToLoadBaseline(
+        testSumId,
+        id,
+        userId,
+      );
+
+      expect(result).toEqual(undefined);
+      expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
+    });
+
+    it('Should throw error when database throws an error while deleting a Fuel Flow To Load Baseline record', async () => {
+      jest
+        .spyOn(repository, 'delete')
+        .mockRejectedValue(new InternalServerErrorException('Unknown Error'));
+      let errored = false;
+
+      try {
+        await service.deleteFuelFlowToLoadBaseline(testSumId, id, userId);
       } catch (e) {
         errored = true;
       }

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
@@ -74,4 +74,50 @@ export class FuelFlowToLoadBaselineWorkspaceService {
     );
     return this.map.one(entity);
   }
+
+  async updateFuelFlowToLoadBaseline(
+    testSumId: string,
+    id: string,
+    payload: FuelFlowToLoadBaselineBaseDTO,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<FuelFlowToLoadBaselineDTO> {
+    const entity = await this.repository.findOne({
+      id,
+      testSumId,
+    });
+
+    if (!entity) {
+      throw new LoggingException(
+        `Fuel Flow To Load Baseline record not found with Record Id [${id}].`,
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    entity.accuracyTestNumber = payload.accuracyTestNumber;
+    entity.peiTestNumber = payload.peiTestNumber;
+    entity.averageFuelFlowRate = payload.averageFuelFlowRate;
+    entity.averageLoad = payload.averageLoad;
+    entity.baselineFuelFlowToLoadRatio = payload.baselineFuelFlowToLoadRatio;
+    entity.fuelFlowToLoadUOMCode = payload.fuelFlowToLoadUOMCode;
+    entity.averageHourlyHeatInputRate = payload.averageHourlyHeatInputRate;
+    entity.baselineGHR = payload.baselineGHR;
+    entity.ghrUnitsOfMeasureCode = payload.ghrUnitsOfMeasureCode;
+
+    entity.numberOfHoursExcludedCofiring =
+      payload.numberOfHoursExcludedCofiring;
+    entity.numberOfHoursExcludedRamping = payload.numberOfHoursExcludedRamping;
+    entity.numberOfHoursExcludedLowRange =
+      payload.numberOfHoursExcludedLowRange;
+
+    await this.repository.save(entity);
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+
+    return this.map.one(entity);
+  }
 }

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
@@ -120,4 +120,30 @@ export class FuelFlowToLoadBaselineWorkspaceService {
 
     return this.map.one(entity);
   }
+
+  async deleteFuelFlowToLoadBaseline(
+    testSumId: string,
+    id: string,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<void> {
+    try {
+      await this.repository.delete({
+        id,
+        testSumId,
+      });
+    } catch (e) {
+      throw new LoggingException(
+        `Error deleting Fuel Flow To Load Baseline record Id [${id}]`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        e,
+      );
+    }
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+  }
 }

--- a/src/linearity-summary-workspace/linearity-summary.service.ts
+++ b/src/linearity-summary-workspace/linearity-summary.service.ts
@@ -6,7 +6,6 @@ import {
   HttpStatus,
   Inject,
   Injectable,
-  InternalServerErrorException,
 } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';

--- a/src/linearity-summary-workspace/linearity-summary.service.ts
+++ b/src/linearity-summary-workspace/linearity-summary.service.ts
@@ -216,9 +216,10 @@ export class LinearitySummaryWorkspaceService {
     try {
       await this.repository.delete(id);
     } catch (e) {
-      throw new InternalServerErrorException(
+      throw new LoggingException(
         `Error deleting Linearity Summary record Id [${id}]`,
-        e.message,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        e,
       );
     }
 


### PR DESCRIPTION
## Feature/3129-3128: EDIT and DELETE API Endpoint - Fuel Flow to Load Baseline Data

## [#3129](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3129)

## [#3128](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3128)
