### PR TITLE
Fix End Date Validation Msg - Undefined Location

### DIFF
--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -315,8 +315,12 @@ export class TestSummaryBaseDTO {
     message: ErrorMessages.SingleFormat('endDate', 'YYYY-MM-DD format'),
   })
   @IsInDateRange(MIN_DATE, new Date(Date.now()).toISOString(), {
-    message: (args: ValidationArguments) =>
-      `You reported an invalid EndDate in the Test Summary record for Location [${args.object['locationId']}], TestTypeCode [${args.object['testTypeCode']}] and TestNumber [${args.object['testNumber']}].`,
+    message: (args: ValidationArguments) => {
+      args.object['locationId'] = args.object['unitId']
+        ? args.object['unitId']
+        : args.object['stackPipeId'];
+      return `You reported an invalid EndDate in the Test Summary record for Location [${args.object['locationId']}], TestTypeCode [${args.object['testTypeCode']}] and TestNumber [${args.object['testNumber']}].`;
+    }
   })
   @ValidateIf(o => VALID_CODES_FOR_END_DATE_VALIDATION.includes(o.testTypeCode))
   endDate?: Date;


### PR DESCRIPTION
Fixed error message that was "Your reported an invalid EndDate .... for Location [undefined] ..."