### PR TITLE
Feature/2899: PUT API Endpoint - Edit Calibration Injection Data

### DIFF
--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
@@ -87,16 +87,16 @@ describe('CalibrationInjectionWorkspaceController', () => {
     });
   });
 
-    describe('updateCalibrationInjection', () => {
-      it('Calls the service and update a existing Calibration Injection record', async () => {
-        const result = await controller.updateCalibrationInjection(
-          locId,
-          testSumId,
-          id,
-          payload,
-          user,
-        );
-        expect(result).toEqual(dto);
-      });
+  describe('updateCalibrationInjection', () => {
+    it('Calls the service and update a existing Calibration Injection record', async () => {
+      const result = await controller.updateCalibrationInjection(
+        locId,
+        testSumId,
+        id,
+        payload,
+        user,
+      );
+      expect(result).toEqual(dto);
     });
+  });
 });

--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
@@ -26,6 +26,7 @@ const dto = new CalibrationInjectionDTO();
 const payload = new CalibrationInjectionBaseDTO();
 
 const mockService = () => ({
+  updateCalibrationInjection: jest.fn().mockResolvedValue(dto),
   createCalibrationInjection: jest.fn().mockResolvedValue(dto),
   getCalibrationInjection: jest.fn().mockResolvedValue(dto),
   getCalibrationInjections: jest.fn().mockResolvedValue([dto]),
@@ -85,4 +86,17 @@ describe('CalibrationInjectionWorkspaceController', () => {
       expect(result).toEqual(dto);
     });
   });
+
+    describe('updateCalibrationInjection', () => {
+      it('Calls the service and update a existing Calibration Injection record', async () => {
+        const result = await controller.updateCalibrationInjection(
+          locId,
+          testSumId,
+          id,
+          payload,
+          user,
+        );
+        expect(result).toEqual(dto);
+      });
+    });
 });

--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiCreatedResponse,
@@ -64,6 +72,28 @@ export class CalibrationInjectionWorkspaceController {
   ): Promise<CalibrationInjectionDTO> {
     return this.service.createCalibrationInjection(
       testSumId,
+      payload,
+      user.userId,
+    );
+  }
+
+  @Put(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    type: CalibrationInjectionDTO,
+    description: 'Updates a workspace Fuel Flow To Load Baseline record.',
+  })
+  updateCalibrationInjection(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @Body() payload: CalibrationInjectionBaseDTO,
+    @User() user: CurrentUser,
+  ): Promise<CalibrationInjectionDTO> {
+    return this.service.updateCalibrationInjection(
+      testSumId,
+      id,
       payload,
       user.userId,
     );

--- a/src/calibration-injection-workspace/calibration-injection-workspace.service.spec.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.service.spec.ts
@@ -123,4 +123,36 @@ describe('CalibrationInjectionWorkspaceService', () => {
       expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
     });
   });
+
+  describe('updateCalibrationInjection', () => {
+    it('Should update and return the Calibration Injection record', async () => {
+      const result = await service.updateCalibrationInjection(
+        testSumId,
+        id,
+        payload,
+        userId,
+      );
+
+      expect(result).toEqual(dto);
+      expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
+    });
+
+    it('Should throw error when a Calibration Injection record not found', async () => {
+      jest.spyOn(repository, 'findOne').mockResolvedValue(undefined);
+      let errored = false;
+
+      try {
+        await service.updateCalibrationInjection(
+          testSumId,
+          id,
+          payload,
+          userId,
+        );
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+    });
+  });
 });

--- a/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
@@ -75,4 +75,51 @@ export class CalibrationInjectionWorkspaceService {
     );
     return this.map.one(entity);
   }
+
+  async updateCalibrationInjection(
+    testSumId: string,
+    id: string,
+    payload: CalibrationInjectionBaseDTO,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<CalibrationInjectionDTO> {
+    const entity = await this.repository.findOne({
+      id,
+      testSumId,
+    });
+
+    if (!entity) {
+      throw new LoggingException(
+        `Calibration Injection record not found with Record Id [${id}].`,
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    entity.onLineOffLineIndicator = payload.onLineOffLineIndicator;
+    entity.upscaleGasLevelCode = payload.upscaleGasLevelCode;
+    entity.zeroInjectionDate = payload.zeroInjectionDate;
+    entity.zeroInjectionHour = payload.zeroInjectionHour;
+    entity.zeroInjectionMinute = payload.zeroInjectionMinute;
+    entity.upscaleInjectionDate = payload.upscaleInjectionDate;
+    entity.upscaleInjectionHour = payload.upscaleInjectionHour;
+    entity.upscaleInjectionMinute = payload.upscaleInjectionMinute;
+    entity.zeroMeasuredValue = payload.zeroMeasuredValue;
+    entity.upscaleMeasuredValue = payload.upscaleMeasuredValue;
+    entity.zeroAPSIndicator = payload.zeroAPSIndicator;
+    entity.upscaleAPSIndicator = payload.upscaleAPSIndicator;
+    entity.zeroCalibrationError = payload.zeroCalibrationError;
+    entity.upscaleCalibrationError = payload.upscaleCalibrationError;
+    entity.zeroReferenceValue = payload.zeroReferenceValue;
+    entity.upscaleReferenceValue = payload.upscaleReferenceValue;
+
+    await this.repository.save(entity);
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+
+    return this.map.one(entity);
+  }
 }

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.spec.ts
@@ -114,7 +114,7 @@ describe('FuelFlowToLoadBaselineWorkspaceService', () => {
   });
 
   describe('updateFuelFlowToLoadBaseline', () => {
-    it('Should update and return a new Fuel Flow To Load Baseline record', async () => {
+    it('Should update and return the Fuel Flow To Load Baseline record', async () => {
       const result = await service.updateFuelFlowToLoadBaseline(
         testSumId,
         id,


### PR DESCRIPTION
## [Feature/2899: PUT API Endpoint - Edit Calibration Injection Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/2899)