### PR TITLE
Feature/4304: DELETE API Endpoint - Remove Calibration Injection Data

### DIFF
--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.spec.ts
@@ -26,6 +26,7 @@ const dto = new CalibrationInjectionDTO();
 const payload = new CalibrationInjectionBaseDTO();
 
 const mockService = () => ({
+  deleteCalibrationInjection: jest.fn().mockResolvedValue(undefined),
   updateCalibrationInjection: jest.fn().mockResolvedValue(dto),
   createCalibrationInjection: jest.fn().mockResolvedValue(dto),
   getCalibrationInjection: jest.fn().mockResolvedValue(dto),
@@ -97,6 +98,18 @@ describe('CalibrationInjectionWorkspaceController', () => {
         user,
       );
       expect(result).toEqual(dto);
+    });
+  });
+
+  describe('deleteCalibrationInjection', () => {
+    it('Calls the service and delete a Calibration Injection record', async () => {
+      const result = await controller.deleteCalibrationInjection(
+        locId,
+        testSumId,
+        id,
+        user,
+      );
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -82,7 +83,7 @@ export class CalibrationInjectionWorkspaceController {
   @ApiBearerAuth('Token')
   @ApiOkResponse({
     type: CalibrationInjectionDTO,
-    description: 'Updates a workspace Fuel Flow To Load Baseline record.',
+    description: 'Updates a workspace Calibration Injection record.',
   })
   updateCalibrationInjection(
     @Param('locId') _locationId: string,
@@ -97,5 +98,20 @@ export class CalibrationInjectionWorkspaceController {
       payload,
       user.userId,
     );
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    description: 'Deletes a workspace Calibration Injection record.',
+  })
+  async deleteCalibrationInjection(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @User() user: CurrentUser,
+  ): Promise<void> {
+    return this.service.deleteCalibrationInjection(testSumId, id, user.userId);
   }
 }

--- a/src/calibration-injection-workspace/calibration-injection-workspace.service.spec.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.service.spec.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common/exceptions';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   CalibrationInjectionBaseDTO,
@@ -148,6 +149,34 @@ describe('CalibrationInjectionWorkspaceService', () => {
           payload,
           userId,
         );
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+    });
+  });
+
+  describe('deleteCalibrationInjection', () => {
+    it('Should delete a Fuel Flow To Load Baseline record', async () => {
+      const result = await service.deleteCalibrationInjection(
+        testSumId,
+        id,
+        userId,
+      );
+
+      expect(result).toEqual(undefined);
+      expect(testSummaryService.resetToNeedsEvaluation).toHaveBeenCalled();
+    });
+
+    it('Should throw error when database throws an error while deleting a Fuel Flow To Load Baseline record', async () => {
+      jest
+        .spyOn(repository, 'delete')
+        .mockRejectedValue(new InternalServerErrorException('Unknown Error'));
+      let errored = false;
+
+      try {
+        await service.deleteCalibrationInjection(testSumId, id, userId);
       } catch (e) {
         errored = true;
       }

--- a/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
@@ -122,4 +122,30 @@ export class CalibrationInjectionWorkspaceService {
 
     return this.map.one(entity);
   }
+
+  async deleteCalibrationInjection(
+    testSumId: string,
+    id: string,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<void> {
+    try {
+      await this.repository.delete({
+        id,
+        testSumId,
+      });
+    } catch (e) {
+      throw new LoggingException(
+        `Error deleting Calibration Injection record [${id}]`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        e,
+      );
+    }
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+  }
 }

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
@@ -107,7 +107,8 @@ export class FuelFlowToLoadBaselineWorkspaceController {
   @UseGuards(AuthGuard)
   @ApiBearerAuth('Token')
   @ApiOkResponse({
-    description: 'Deletes a Linearity Summary record from the workspace',
+    description:
+      'Deletes a Fuel Flow To Load Baseline record from the workspace',
   })
   async deleteFuelFlowToLoadBaseline(
     @Param('locId') _locationId: string,

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
@@ -134,7 +134,7 @@ export class FuelFlowToLoadBaselineWorkspaceService {
       });
     } catch (e) {
       throw new LoggingException(
-        `Error deleting Fuel Flow To Load Baseline record Id [${id}]`,
+        `Error deleting Fuel Flow To Load Baseline record [${id}]`,
         HttpStatus.INTERNAL_SERVER_ERROR,
         e,
       );


### PR DESCRIPTION
## [Feature/4304: DELETE API Endpoint - Remove Calibration Injection Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/4304)