### PR TITLE
Bug Fix: Reference to TestSummary from ProtocolGas

### DIFF
--- a/src/entities/protocol-gas.entity.ts
+++ b/src/entities/protocol-gas.entity.ts
@@ -72,7 +72,7 @@ export class ProtocolGas extends BaseEntity {
 
   @ManyToOne(
     () => TestSummary,
-    o => o.linearitySummaries,
+    o => o.protocolGases,
   )
   @JoinColumn({ name: 'test_sum_id' })
   testSummary: TestSummary;

--- a/src/entities/workspace/protocol-gas.entity.ts
+++ b/src/entities/workspace/protocol-gas.entity.ts
@@ -72,7 +72,7 @@ export class ProtocolGas extends BaseEntity {
 
   @ManyToOne(
     () => TestSummary,
-    o => o.linearitySummaries,
+    o => o.protocolGases,
   )
   @JoinColumn({ name: 'test_sum_id' })
   testSummary: TestSummary;


### PR DESCRIPTION
Many-To-One reference from Protocol Gas was referencing LinearitySummaries in TestSummary.  Corrected to protocolGases property.