### PR TITLE
feature 3141 - Add API Endpoint to Update On/Offline Calibration

### DIFF
--- a/src/online-offline-calibration-workspace/online-offline-calibration.controller.spec.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.controller.spec.ts
@@ -34,6 +34,7 @@ const mockService = () => ({
     .fn()
     .mockResolvedValue(onlineOfflineCalibrationRecord),
   createOnlineOfflineCalibration: jest.fn(),
+  updateOnlineOfflineCalibration: jest.fn(),
 });
 
 const mockAuthGuard = () => ({});
@@ -107,7 +108,18 @@ describe('Online Offline Calibration Workspace Controller', () => {
       jest
         .spyOn(service, 'createOnlineOfflineCalibration')
         .mockResolvedValue(onlineOfflineCalibrationRecord);
-      expect(await controller.create(locId, testSumId, payload, user)).toEqual(
+      expect(await controller.createOnlineOfflineCalibration(locId, testSumId, payload, user)).toEqual(
+        onlineOfflineCalibrationRecord,
+      );
+    });
+  });
+
+  describe('updateOnlineOfflineCalibration', () => {
+    it('Should call the service to update an existing record', async () => {
+      jest
+        .spyOn(service, 'updateOnlineOfflineCalibration')
+        .mockResolvedValue(onlineOfflineCalibrationRecord);
+      expect(await controller.updateOnlineOfflineCalibration(locId, testSumId, onlineOfflineCalibrationId, payload, user)).toEqual(
         onlineOfflineCalibrationRecord,
       );
     });

--- a/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Post,
+  Put,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -69,7 +70,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     description:
       'Creates an Online Offline Calibration record in the workspace',
   })
-  async create(
+  async createOnlineOfflineCalibration(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
     @Body() payload: OnlineOfflineCalibrationBaseDTO,
@@ -99,5 +100,22 @@ export class OnlineOfflineCalibrationWorkspaceController {
       id,
       user.userId,
     );
+  }
+
+  @Put(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    type: OnlineOfflineCalibrationRecordDTO,
+    description: 'Updates an Online Offline Calibration record in the workspace',
+  })
+  async updateOnlineOfflineCalibration(
+    @Param('locid') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @Body() payload: OnlineOfflineCalibrationBaseDTO,
+    @User() user: CurrentUser,
+  ) {
+    return this.service.updateOnlineOfflineCalibration(testSumId, id, payload, user.userId);
   }
 }

--- a/src/online-offline-calibration-workspace/online-offline-calibration.service.spec.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.service.spec.ts
@@ -139,4 +139,17 @@ describe('OnlineOfflineCalibrationWorkspaceService', () => {
       expect(errored).toEqual(true);
     });
   });
+
+  describe('updateOnlineOfflineCalibration', () => {
+    it('Calls the repository to update an existing Online Offline Calibration record', async () => {
+      const result = await service.updateOnlineOfflineCalibration(
+        testSumId,
+        onlineOfflineCalibrationId,
+        payload,
+        userId,
+      );
+      expect(result).toEqual(onlineOfflineCalibrationDTO);
+      expect(repository.save).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/online-offline-calibration-workspace/online-offline-calibration.service.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.service.ts
@@ -16,6 +16,7 @@ import { OnlineOfflineCalibrationWorkspaceRepository } from './online-offline-ca
 import { OnlineOfflineCalibrationMap } from '../maps/online-offline-calibration.map';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
+import { ProtocolGasBaseDTO, ProtocolGasDTO } from '../dto/protocol-gas.dto';
 
 @Injectable()
 export class OnlineOfflineCalibrationWorkspaceService {
@@ -100,11 +101,64 @@ export class OnlineOfflineCalibrationWorkspaceService {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
+  
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+
+  }
+
+
+  async updateOnlineOfflineCalibration(
+    testSumId: string,
+    id: string,
+    payload: OnlineOfflineCalibrationBaseDTO,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<OnlineOfflineCalibrationDTO> {
+    const timestamp = currentDateTime().toLocaleString();
+
+    const entity = await this.getOnlineOfflineCalibration(id);
+
+    entity.offlineUpscaleAPSIndicator = payload.offlineUpscaleAPSIndicator;
+    entity.offlineZeroAPSIndicator = payload.offlineZeroAPSIndicator;
+    entity.onlineUpscaleAPSIndicator = payload.onlineUpscaleAPSIndicator;
+    entity.onlineZeroAPSIndicator = payload.onlineZeroAPSIndicator;
+    entity.offlineUpscaleCalibrationError = payload.offlineUpscaleCalibrationError;
+    entity.offlineUpscaleInjectionDate = payload.offlineUpscaleInjectionDate;
+    entity.offlineUpscaleInjectionHour = payload.offlineUpscaleInjectionHour;
+    entity.offlineUpscaleMeasuredValue = payload.offlineUpscaleMeasuredValue;
+    entity.offlineUpscaleReferenceValue = payload.offlineUpscaleReferenceValue;
+    entity.offlineZeroCalibrationError = payload.offlineZeroCalibrationError;
+    entity.offlineZeroInjectionDate = payload.offlineZeroInjectionDate;
+    entity.offlineZeroInjectionHour = payload.offlineZeroInjectionHour;
+    entity.offlineZeroMeasuredValue = payload.offlineZeroMeasuredValue;
+    entity.offlineZeroReferenceValue = payload.offlineZeroReferenceValue;
+    entity.onlineUpscaleCalibrationError = payload.onlineUpscaleCalibrationError;
+    entity.onlineUpscaleInjectionDate = payload.onlineUpscaleInjectionDate;
+    entity.onlineUpscaleInjectionHour = payload.onlineUpscaleInjectionHour;
+    entity.onlineUpscaleMeasuredValue = payload.onlineUpscaleMeasuredValue;
+    entity.onlineUpscaleReferenceValue = payload.onlineUpscaleReferenceValue;
+    entity.onlineZeroCalibrationError = payload.onlineZeroCalibrationError;
+    entity.onlineZeroInjectionDate = payload.onlineZeroInjectionDate;
+    entity.onlineZeroInjectionHour = payload.onlineZeroInjectionHour;
+    entity.onlineZeroMeasuredValue = payload.onlineZeroMeasuredValue;
+    entity.onlineZeroReferenceValue = payload.onlineZeroReferenceValue;
+    entity.upscaleGasLevelCode = payload.upscaleGasLevelCode;
+
+    entity.userId = userId;
+    entity.updateDate = timestamp;
+
+    await this.repository.save(entity);
 
     await this.testSummaryService.resetToNeedsEvaluation(
       testSumId,
       userId,
       isImport,
     );
+
+    return this.getOnlineOfflineCalibration(id);
   }
 }


### PR DESCRIPTION
Adds an API Endpoint to update an existing Online Offline Calibration Record