### PR TITLE
Feature/4446-4447: Add Cycle Time Injection data elements to Export and Import Endpoint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "tabnine.tabnine-vscode"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,0 @@
-{
-  "recommendations": [
-    "tabnine.tabnine-vscode"
-  ]
-}

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.module.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.module.ts
@@ -8,10 +8,12 @@ import { CycleTimeInjectionWorkspaceRepository } from './cycle-time-injection-wo
 import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
 import { CycleTimeSummaryWorkspaceModule } from '../cycle-time-summary-workspace/cycle-time-summary-workspace.module';
 import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
+import { CycleTimeInjectionModule } from '../cycle-time-injection/cycle-time-injection.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([CycleTimeInjectionWorkspaceRepository]),
+    forwardRef(() => CycleTimeInjectionModule),
     forwardRef(() => TestSummaryWorkspaceModule),
     forwardRef(() => CycleTimeSummaryWorkspaceModule),
     HttpModule,

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
@@ -126,7 +126,7 @@ describe('CycleTimeInjectionWorkspaceService', () => {
 
   describe('import', () => {
     const importPayload = new CycleTimeInjectionImportDTO();
-    it('Should Import Cycle Time Summary', async () => {
+    it('Should Import Cycle Time Injection', async () => {
       jest
         .spyOn(service, 'createCycleTimeInjection')
         .mockResolvedValue(cycleTimeInjectionDTO);
@@ -141,7 +141,7 @@ describe('CycleTimeInjectionWorkspaceService', () => {
       expect(result).toEqual(null);
     });
 
-    it('Should Import Cycle Time Summary from Historical Record', async () => {
+    it('Should Import Cycle Time Injection from Historical Record', async () => {
       jest
         .spyOn(service, 'createCycleTimeInjection')
         .mockResolvedValue(cycleTimeInjectionDTO);

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
@@ -83,4 +83,24 @@ describe('CycleTimeInjectionWorkspaceService', () => {
       expect(result).toEqual(cycleTimeInjectionDTO);
     });
   });
+
+  describe('getCycleTimeInjectionByCycleTimeSumIds', () => {
+    it('Should get Cycle Time injection records by cycleTimeSumIds', async () => {
+      const result = await service.getCycleTimeInjectionByCycleTimeSumIds([
+        cycleTimeSumId,
+      ]);
+      expect(result).toEqual([cycleTimeInjectionDTO]);
+    });
+  });
+
+  describe('export', () => {
+    it('Should export Cycle Time Injection Record', async () => {
+      jest
+        .spyOn(service, 'getCycleTimeInjectionByCycleTimeSumIds')
+        .mockResolvedValue([]);
+
+      const result = await service.export([cycleTimeSumId]);
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.spec.ts
@@ -5,21 +5,20 @@ import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
 import {
   CycleTimeInjectionDTO,
   CycleTimeInjectionImportDTO,
-  CycleTimeInjectionRecordDTO,
 } from '../dto/cycle-time-injection.dto';
 import { CycleTimeInjection } from '../entities/workspace/cycle-time-injection.entity';
+import { CycleTimeInjection as CycleTimeInjectionOfficial } from '../entities/cycle-time-injection.entity';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
 import { CycleTimeInjectionWorkspaceRepository } from './cycle-time-injection-workspace.repository';
 import { CycleTimeInjectionWorkspaceService } from './cycle-time-injection-workspace.service';
+import { CycleTimeInjectionRepository } from '../cycle-time-injection/cycle-time-injection.repository';
 
 const testSumId = '1';
 const cycleTimeSumId = '1';
-const cycleTimeInjId = '1';
 const userId = 'testuser';
 
 const cycleTimeInjection = new CycleTimeInjection();
 const cycleTimeInjectionDTO = new CycleTimeInjectionDTO();
-const cycleTimeInjectionRecordDto = new CycleTimeInjectionRecordDTO();
 
 const payload = new CycleTimeInjectionImportDTO();
 
@@ -38,6 +37,10 @@ const mockMap = () => ({
   many: jest.fn().mockResolvedValue([cycleTimeInjectionDTO]),
 });
 
+const mockHistoricalRepo = () => ({
+  findOne: jest.fn().mockResolvedValue(new CycleTimeInjectionOfficial()),
+});
+
 describe('CycleTimeInjectionWorkspaceService', () => {
   let service: CycleTimeInjectionWorkspaceService;
 
@@ -53,6 +56,10 @@ describe('CycleTimeInjectionWorkspaceService', () => {
         {
           provide: CycleTimeInjectionWorkspaceRepository,
           useFactory: mockRepository,
+        },
+        {
+          provide: CycleTimeInjectionRepository,
+          useFactory: mockHistoricalRepo,
         },
         {
           provide: CycleTimeInjectionMap,
@@ -82,6 +89,19 @@ describe('CycleTimeInjectionWorkspaceService', () => {
       );
       expect(result).toEqual(cycleTimeInjectionDTO);
     });
+
+    it('Should create and return a new Cycle Time Injection record with Historical Record Id', async () => {
+      const result = await service.createCycleTimeInjection(
+        testSumId,
+        cycleTimeSumId,
+        payload,
+        userId,
+        false,
+        'historicalId',
+      );
+
+      expect(result).toEqual(cycleTimeInjectionDTO);
+    });
   });
 
   describe('getCycleTimeInjectionByCycleTimeSumIds', () => {
@@ -101,6 +121,39 @@ describe('CycleTimeInjectionWorkspaceService', () => {
 
       const result = await service.export([cycleTimeSumId]);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('import', () => {
+    const importPayload = new CycleTimeInjectionImportDTO();
+    it('Should Import Cycle Time Summary', async () => {
+      jest
+        .spyOn(service, 'createCycleTimeInjection')
+        .mockResolvedValue(cycleTimeInjectionDTO);
+
+      const result = await service.import(
+        testSumId,
+        cycleTimeSumId,
+        importPayload,
+        userId,
+        false,
+      );
+      expect(result).toEqual(null);
+    });
+
+    it('Should Import Cycle Time Summary from Historical Record', async () => {
+      jest
+        .spyOn(service, 'createCycleTimeInjection')
+        .mockResolvedValue(cycleTimeInjectionDTO);
+
+      const result = await service.import(
+        testSumId,
+        cycleTimeSumId,
+        importPayload,
+        userId,
+        true,
+      );
+      expect(result).toEqual(null);
     });
   });
 });

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.service.ts
@@ -6,12 +6,14 @@ import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '../utilities/functions';
 import {
   CycleTimeInjectionBaseDTO,
+  CycleTimeInjectionDTO,
   CycleTimeInjectionImportDTO,
   CycleTimeInjectionRecordDTO,
 } from '../dto/cycle-time-injection.dto';
 import { CycleTimeInjectionWorkspaceRepository } from './cycle-time-injection-workspace.repository';
 import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
 import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summary.service';
+import { In } from 'typeorm';
 
 @Injectable()
 export class CycleTimeInjectionWorkspaceService {
@@ -53,5 +55,18 @@ export class CycleTimeInjectionWorkspaceService {
     );
 
     return this.map.one(entity);
+  }
+
+  async getCycleTimeInjectionByCycleTimeSumIds(
+    cycleTimeSumIds: string[],
+  ): Promise<CycleTimeInjectionDTO[]> {
+    const results = await this.repository.find({
+      where: { cycleTimeSumId: In(cycleTimeSumIds) },
+    });
+    return this.map.many(results);
+  }
+
+  async export(cycleTimeSumIds: string[]): Promise<CycleTimeInjectionDTO[]> {
+    return this.getCycleTimeInjectionByCycleTimeSumIds(cycleTimeSumIds);
   }
 }

--- a/src/cycle-time-injection/cycle-time-injection.controller.spec.ts
+++ b/src/cycle-time-injection/cycle-time-injection.controller.spec.ts
@@ -1,5 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
 import { CycleTimeInjectionController } from './cycle-time-injection.controller';
+import { CycleTimeInjectionRepository } from './cycle-time-injection.repository';
 import { CycleTimeInjectionService } from './cycle-time-injection.service';
 
 describe('CycleTimeInjectionController', () => {
@@ -8,7 +10,17 @@ describe('CycleTimeInjectionController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CycleTimeInjectionController],
-      providers: [CycleTimeInjectionService],
+      providers: [
+        CycleTimeInjectionService,
+        {
+          provide: CycleTimeInjectionRepository,
+          useFactory: () => ({}),
+        },
+        {
+          provide: CycleTimeInjectionMap,
+          useFactory: () => ({}),
+        },
+      ],
     }).compile();
 
     controller = module.get<CycleTimeInjectionController>(

--- a/src/cycle-time-injection/cycle-time-injection.service.spec.ts
+++ b/src/cycle-time-injection/cycle-time-injection.service.spec.ts
@@ -1,12 +1,40 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
+import { CycleTimeInjectionDTO } from '../dto/cycle-time-injection.dto';
+import { CycleTimeInjection } from '../entities/cycle-time-injection.entity';
+import { CycleTimeInjectionRepository } from './cycle-time-injection.repository';
 import { CycleTimeInjectionService } from './cycle-time-injection.service';
+
+const cycleTimeSumId = '1';
+
+const cycleTimeInjection = new CycleTimeInjection();
+const cycleTimeInjectionDTO = new CycleTimeInjectionDTO();
+
+const mockRepository = () => ({
+  find: jest.fn().mockResolvedValue([cycleTimeInjection]),
+});
+
+const mockMap = () => ({
+  one: jest.fn().mockResolvedValue(cycleTimeInjectionDTO),
+  many: jest.fn().mockResolvedValue([cycleTimeInjectionDTO]),
+});
 
 describe('CycleTimeInjectionService', () => {
   let service: CycleTimeInjectionService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CycleTimeInjectionService],
+      providers: [
+        CycleTimeInjectionService,
+        {
+          provide: CycleTimeInjectionRepository,
+          useFactory: mockRepository,
+        },
+        {
+          provide: CycleTimeInjectionMap,
+          useFactory: mockMap,
+        },
+      ],
     }).compile();
 
     service = module.get<CycleTimeInjectionService>(CycleTimeInjectionService);
@@ -14,5 +42,25 @@ describe('CycleTimeInjectionService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getCycleTimeInjectionByCycleTimeSumIds', () => {
+    it('Should get Cycle Time injection records by cycleTimeSumIds', async () => {
+      const result = await service.getCycleTimeInjectionByCycleTimeSumIds([
+        cycleTimeSumId,
+      ]);
+      expect(result).toEqual([cycleTimeInjectionDTO]);
+    });
+  });
+
+  describe('export', () => {
+    it('Should export Cycle Time Injection Record', async () => {
+      jest
+        .spyOn(service, 'getCycleTimeInjectionByCycleTimeSumIds')
+        .mockResolvedValue([]);
+
+      const result = await service.export([cycleTimeSumId]);
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/src/cycle-time-injection/cycle-time-injection.service.ts
+++ b/src/cycle-time-injection/cycle-time-injection.service.ts
@@ -1,4 +1,28 @@
 import { Injectable } from '@nestjs/common';
+import { CycleTimeInjectionDTO } from '../dto/cycle-time-injection.dto';
+import { In } from 'typeorm';
+import { CycleTimeInjectionMap } from '../maps/cycle-time-injection.map';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CycleTimeInjectionRepository } from './cycle-time-injection.repository';
 
 @Injectable()
-export class CycleTimeInjectionService {}
+export class CycleTimeInjectionService {
+  constructor(
+    private readonly map: CycleTimeInjectionMap,
+    @InjectRepository(CycleTimeInjectionRepository)
+    private readonly repository: CycleTimeInjectionRepository,
+  ) {}
+
+  async getCycleTimeInjectionByCycleTimeSumIds(
+    cycleTimeSumIds: string[],
+  ): Promise<CycleTimeInjectionDTO[]> {
+    const results = await this.repository.find({
+      where: { cycleTimeSumId: In(cycleTimeSumIds) },
+    });
+    return this.map.many(results);
+  }
+
+  async export(cycleTimeSumIds: string[]): Promise<CycleTimeInjectionDTO[]> {
+    return this.getCycleTimeInjectionByCycleTimeSumIds(cycleTimeSumIds);
+  }
+}

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.spec.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.spec.ts
@@ -14,7 +14,10 @@ import { Logger } from '@us-epa-camd/easey-common/logger';
 import { InternalServerErrorException } from '@nestjs/common';
 import { CycleTimeSummaryRepository } from '../cycle-time-summary/cycle-time-summary.repository';
 import { CycleTimeInjectionWorkspaceService } from '../cycle-time-injection-workspace/cycle-time-injection-workspace.service';
-import { CycleTimeInjectionDTO } from '../dto/cycle-time-injection.dto';
+import {
+  CycleTimeInjectionDTO,
+  CycleTimeInjectionImportDTO,
+} from '../dto/cycle-time-injection.dto';
 
 const id = '';
 const testSumId = '';
@@ -229,6 +232,9 @@ describe('CycleTimeSummaryWorkspaceService', () => {
     });
 
     it('Should Import Cycle Time Summary from Historical Record', async () => {
+      importPayload.cycleTimeInjectionData = [
+        new CycleTimeInjectionImportDTO(),
+      ];
       jest.spyOn(service, 'createCycleTimeSummary').mockResolvedValue(dto);
 
       await service.import(testSumId, importPayload, userId, true);

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.spec.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.spec.ts
@@ -13,6 +13,8 @@ import { CycleTimeSummaryWorkspaceService } from './cycle-time-summary-workspace
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { InternalServerErrorException } from '@nestjs/common';
 import { CycleTimeSummaryRepository } from '../cycle-time-summary/cycle-time-summary.repository';
+import { CycleTimeInjectionWorkspaceService } from '../cycle-time-injection-workspace/cycle-time-injection-workspace.service';
+import { CycleTimeInjectionDTO } from '../dto/cycle-time-injection.dto';
 
 const id = '';
 const testSumId = '';
@@ -22,6 +24,9 @@ const dto = new CycleTimeSummaryDTO();
 
 const payload = new CycleTimeSummaryBaseDTO();
 const importPayload = new CycleTimeSummaryImportDTO();
+
+const cycleTimeInjDto = new CycleTimeInjectionDTO();
+cycleTimeInjDto.cycleTimeSumId = 'SOME_ID';
 
 const mockRepository = () => ({
   find: jest.fn().mockResolvedValue([entity]),
@@ -34,6 +39,11 @@ const mockRepository = () => ({
 const mockMap = () => ({
   one: jest.fn().mockResolvedValue(dto),
   many: jest.fn().mockResolvedValue([dto]),
+});
+
+const mockCycleTimeInjectionService = () => ({
+  import: jest.fn(),
+  export: jest.fn().mockResolvedValue([cycleTimeInjDto]),
 });
 
 const mockTestSumService = () => ({
@@ -56,6 +66,10 @@ describe('CycleTimeSummaryWorkspaceService', () => {
         {
           provide: TestSummaryWorkspaceService,
           useFactory: mockTestSumService,
+        },
+        {
+          provide: CycleTimeInjectionWorkspaceService,
+          useFactory: mockCycleTimeInjectionService,
         },
         {
           provide: CycleTimeSummaryWorkspaceRepository,
@@ -195,12 +209,15 @@ describe('CycleTimeSummaryWorkspaceService', () => {
 
   describe('export', () => {
     it('Should export Cycle Time Summary Record', async () => {
+      dto.id = 'SOME_ID';
+
       jest
         .spyOn(service, 'getCycleTimeSummaryByTestSumIds')
-        .mockResolvedValue([]);
+        .mockResolvedValue([dto]);
 
       const result = await service.export([testSumId]);
-      expect(result).toEqual([]);
+      dto.cycleTimeInjectionData = [cycleTimeInjDto];
+      expect(result).toEqual([dto]);
     });
   });
 

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.ts
@@ -179,6 +179,7 @@ export class CycleTimeSummaryWorkspaceService {
     isHistoricalRecord?: boolean,
   ) {
     const isImport = true;
+    const promises = [];
     let historicalRecord: CycleTimeSummary;
 
     if (isHistoricalRecord) {
@@ -199,6 +200,29 @@ export class CycleTimeSummaryWorkspaceService {
     this.logger.info(
       `Cycle Time Summary Successfully Imported. Record Id: ${createdCycleTimeSummary.id}`,
     );
+
+    if (payload.cycleTimeInjectionData?.length > 0) {
+      for (const cycleTimeInjection of payload.cycleTimeInjectionData) {
+        promises.push(
+          new Promise(async (resolve, _reject) => {
+            const innerPromises = [];
+            innerPromises.push(
+              this.cycleTimeInjectionService.import(
+                testSumId,
+                createdCycleTimeSummary.id,
+                cycleTimeInjection,
+                userId,
+                isHistoricalRecord,
+              ),
+            );
+            await Promise.all(innerPromises);
+            resolve(true);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(promises);
 
     return null;
   }

--- a/src/cycle-time-summary/cycle-time-summary.service.spec.ts
+++ b/src/cycle-time-summary/cycle-time-summary.service.spec.ts
@@ -6,11 +6,16 @@ import { CycleTimeSummaryDTO } from '../dto/cycle-time-summary.dto';
 import { CycleTimeSummary } from '../entities/workspace/cycle-time-summary.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { CycleTimeSummaryRepository } from './cycle-time-summary.repository';
+import { CycleTimeInjectionDTO } from '../dto/cycle-time-injection.dto';
+import { CycleTimeInjectionService } from '../cycle-time-injection/cycle-time-injection.service';
 
 const id = '';
 const testSumId = '';
 const entity = new CycleTimeSummary();
 const dto = new CycleTimeSummaryDTO();
+
+const cycleTimeInjDto = new CycleTimeInjectionDTO();
+cycleTimeInjDto.cycleTimeSumId = 'SOME_ID';
 
 const mockRepository = () => ({
   find: jest.fn().mockResolvedValue([entity]),
@@ -22,6 +27,11 @@ const mockMap = () => ({
   many: jest.fn().mockResolvedValue([dto]),
 });
 
+const mockCycleTimeInjectionService = () => ({
+  import: jest.fn(),
+  export: jest.fn().mockResolvedValue([cycleTimeInjDto]),
+});
+
 describe('CycleTimeSummaryService', () => {
   let service: CycleTimeSummaryService;
   let repository: CycleTimeSummaryRepository;
@@ -31,6 +41,10 @@ describe('CycleTimeSummaryService', () => {
       providers: [
         Logger,
         CycleTimeSummaryService,
+        {
+          provide: CycleTimeInjectionService,
+          useFactory: mockCycleTimeInjectionService,
+        },
         {
           provide: CycleTimeSummaryRepository,
           useFactory: mockRepository,
@@ -86,12 +100,14 @@ describe('CycleTimeSummaryService', () => {
 
   describe('export', () => {
     it('Should export Cycle Time Summary Record', async () => {
+      dto.id = 'SOME_ID';
       jest
         .spyOn(service, 'getCycleTimeSummaryByTestSumIds')
-        .mockResolvedValue([]);
+        .mockResolvedValue([dto]);
 
       const result = await service.export([testSumId]);
-      expect(result).toEqual([]);
+      dto.cycleTimeInjectionData = [cycleTimeInjDto];
+      expect(result).toEqual([dto]);
     });
   });
 });


### PR DESCRIPTION
## Feature/4446-4447: Add Cycle Time Injection data elements to Export and Import Endpoint

## [4446](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/4446)

## [4447](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/4447)