### PR TITLE
Exclude TransmitterTransducerAccuracy from TEST-8

### DIFF
--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -906,7 +906,8 @@ export class TestSummaryChecksService {
       if (
         component &&
         component.componentTypeCode !== 'FLOW' &&
-        summary.testTypeCode !== 'FFACC'
+        summary.testTypeCode !== TestTypeCodes.FFACC &&
+        summary.testTypeCode !== TestTypeCodes.FFACCTT 
       ) {
         if (summary.spanScaleCode === null) {
           return this.getMessage('TEST-8-A', {


### PR DESCRIPTION
Excludes the Transmitter Transducer Accuracy Test Type from Test Summary Check 8 (Span Scale Code)