### PR TITLE
✨ Feature/3086: API Endpoint - Remove Hg Summary Data

### DIFF
--- a/src/hg-summary-workspace/hg-summary-workspace.controller.spec.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.controller.spec.ts
@@ -27,6 +27,7 @@ const mockService = () => ({
   updateHgSummary: jest.fn().mockResolvedValue(dto),
   getHgSummary: jest.fn().mockResolvedValue(dto),
   getHgSummaries: jest.fn().mockResolvedValue([dto]),
+  deleteHgSummary: jest.fn().mockResolvedValue(undefined),
 });
 
 describe('HgSummaryWorkspaceController', () => {
@@ -87,6 +88,18 @@ describe('HgSummaryWorkspaceController', () => {
         user,
       );
       expect(result).toEqual(dto);
+    });
+  });
+
+  describe('deleteHgSummary', () => {
+    it('Calls the service and delete a Hg Summary record', async () => {
+      const result = await controller.deleteHgSummary(
+        locId,
+        testSumId,
+        id,
+        user,
+      );
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/src/hg-summary-workspace/hg-summary-workspace.controller.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -84,5 +85,20 @@ export class HgSummaryWorkspaceController {
     @User() user: CurrentUser,
   ): Promise<HgSummaryDTO> {
     return this.service.updateHgSummary(testSumId, id, payload, user.userId);
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiOkResponse({
+    description: 'Deletes a workspace Hg Summary record.',
+  })
+  async deleteHgSummary(
+    @Param('locId') _locationId: string,
+    @Param('testSumId') testSumId: string,
+    @Param('id') id: string,
+    @User() user: CurrentUser,
+  ): Promise<void> {
+    return this.service.deleteHgSummary(testSumId, id, user.userId);
   }
 }

--- a/src/hg-summary-workspace/hg-summary-workspace.service.spec.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.service.spec.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HgSummaryBaseDTO, HgSummaryDTO } from '../dto/hg-summary.dto';
 import { HgSummary } from '../entities/workspace/hg-summary.entity';
@@ -127,6 +128,29 @@ describe('HgSummaryWorkspaceService', () => {
 
       try {
         await service.updateHgSummary(testSumId, id, payload, userId);
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+    });
+  });
+
+  describe('deleteHgSummary', () => {
+    it('Should delete a Hg Summary record', async () => {
+      const result = await service.deleteHgSummary(testSumId, id, userId);
+
+      expect(result).toEqual(undefined);
+    });
+
+    it('Should throw error when database throws an error while deleting a Hg Summary record', async () => {
+      jest
+        .spyOn(repository, 'delete')
+        .mockRejectedValue(new InternalServerErrorException('Unknown Error'));
+      let errored = false;
+
+      try {
+        await service.deleteHgSummary(testSumId, id, userId);
       } catch (e) {
         errored = true;
       }

--- a/src/hg-summary-workspace/hg-summary-workspace.service.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.service.ts
@@ -103,4 +103,30 @@ export class HgSummaryWorkspaceService {
 
     return this.map.one(entity);
   }
+
+  async deleteHgSummary(
+    testSumId: string,
+    id: string,
+    userId: string,
+    isImport: boolean = false,
+  ): Promise<void> {
+    try {
+      await this.repository.delete({
+        id,
+        testSumId,
+      });
+    } catch (e) {
+      throw new LoggingException(
+        `Error deleting Hg Summary record [${id}]`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        e,
+      );
+    }
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
+  }
 }


### PR DESCRIPTION
## [✨Feature/3086: API Endpoint - Remove Hg Summary Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/3086)
