### PR TITLE
🐛 Bug/4600: Test Summary Modal displaying a minute feild error

### DIFF
--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -100,6 +100,7 @@ import {
   YEAR_QUARTER_TEST_TYPE_CODES,
   GRACE_PERIOD_IND_TEST_TYPE_CODES,
   VALID_CODES_FOR_END_DATE_VALIDATION,
+  BEGIN_MINUTE_TEST_TYPE_CODES,
 } from '../utilities/constants';
 import { dataDictionary, getMetadata, MetadataKeys } from '../data-dictionary';
 import { TestTypeCodes } from '../enums/test-type-code.enum';
@@ -303,7 +304,7 @@ export class TestSummaryBaseDTO {
     message: (args: ValidationArguments) =>
       `The value [${args.value}] in the field [beginMinute] for [${KEY}] is not within the range of valid values from [${MIN_MINUTE}] to [${MAX_MINUTE}].`,
   })
-  @ValidateIf(o => BEGIN_DATE_TEST_TYPE_CODES.includes(o.testTypeCode))
+  @ValidateIf(o => BEGIN_MINUTE_TEST_TYPE_CODES.includes(o.testTypeCode))
   beginMinute?: number;
 
   @ApiProperty({

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -36,6 +36,17 @@ export const BEGIN_DATE_TEST_TYPE_CODES = [
   TestTypeCodes.SEVENDAY.toString(),
 ];
 
+export const BEGIN_MINUTE_TEST_TYPE_CODES = [
+  TestTypeCodes.UNITDEF.toString(),
+  TestTypeCodes.APPE.toString(),
+  TestTypeCodes.RATA.toString(),
+  TestTypeCodes.HGSI3.toString(),
+  TestTypeCodes.HGLINE.toString(),
+  TestTypeCodes.LINE.toString(),
+  TestTypeCodes.CYCLE.toString(),
+  TestTypeCodes.SEVENDAY.toString(),
+];
+
 export const VALID_CODES_FOR_COMPONENT_ID_VALIDATION = [
   TestTypeCodes.FFACCTT,
   TestTypeCodes.FFACC,


### PR DESCRIPTION
## [🐛 Bug/4600: Test Summary Modal displaying a minute feild error](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4600)