### PR TITLE
Feature/4206 refactor check messages

### DIFF
--- a/src/dto/linearity-injection.dto.ts
+++ b/src/dto/linearity-injection.dto.ts
@@ -16,7 +16,10 @@ export class LinearityInjectionBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-19-A', {
+        type: args.value,
+        key: KEY,
+      });
     },
   })
   injectionDate: Date;
@@ -26,7 +29,10 @@ export class LinearityInjectionBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-19-A', {
+        type: args.value,
+        key: KEY,
+      });
     },
   })
   @IsInRange(MIN_HOUR, MAX_HOUR, {
@@ -44,7 +50,10 @@ export class LinearityInjectionBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-19-A', {
+        type: args.value,
+        key: KEY,
+      });
     },
   })
   @IsInRange(MIN_MINUTE, MAX_MINUTE, {

--- a/src/dto/linearity-injection.dto.ts
+++ b/src/dto/linearity-injection.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInRange } from '@us-epa-camd/easey-common/pipes';
 import { IsNotEmpty, ValidationArguments } from 'class-validator';
 import { IsNotNegative } from '../pipes/is-not-negative.pipe';
@@ -29,8 +30,12 @@ export class LinearityInjectionBaseDTO {
     },
   })
   @IsInRange(MIN_HOUR, MAX_HOUR, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [injectionHour] for [${KEY}] is not within the range of valid values from [${MIN_HOUR}] to [${MAX_HOUR}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('LINEAR-19-A', {
+        type: args.value,
+        key: KEY,
+      });
+    },
   })
   injectionHour: number;
 
@@ -43,8 +48,12 @@ export class LinearityInjectionBaseDTO {
     },
   })
   @IsInRange(MIN_MINUTE, MAX_MINUTE, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [injectionMinute] for [${KEY}] is not within the range of valid values from [${MIN_MINUTE}] to [${MAX_MINUTE}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('LINEAR-19-A', {
+        type: args.value,
+        key: KEY,
+      });
+    },
   })
   injectionMinute: number;
 
@@ -53,7 +62,10 @@ export class LinearityInjectionBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-20-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   measuredValue: number;
@@ -63,12 +75,19 @@ export class LinearityInjectionBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-21-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @IsNotNegative({
     message: (args: ValidationArguments) => {
-      return `The value [${args.value}] in the field [${args.property}] for [${KEY}] is not within the range of valid values. This value must be greater than or equal to zero.`;
+      return CheckCatalogService.formatResultMessage('LINEAR-21-B', {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   referenceValue: number;

--- a/src/dto/linearity-summary.dto.ts
+++ b/src/dto/linearity-summary.dto.ts
@@ -14,6 +14,7 @@ import {
 } from './linearity-injection.dto';
 import { GasLevelCode } from '../entities/workspace/gas-level-code.entity';
 import { dataDictionary, getMetadata, MetadataKeys } from '../data-dictionary';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
 const KEY = 'Linearity Summary';
 
@@ -23,12 +24,18 @@ export class LinearitySummaryBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-15-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @IsValidCode(GasLevelCode, {
     message: (args: ValidationArguments) => {
-      return `You reported an invalid gas level code of [${args.value}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-15-B', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   gasLevelCode: string;
@@ -38,7 +45,10 @@ export class LinearitySummaryBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-16-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   meanMeasuredValue: number;
@@ -48,12 +58,19 @@ export class LinearitySummaryBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-17-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @IsNotNegative({
     message: (args: ValidationArguments) => {
-      return `The value [${args.value}] in the field [${args.property}] for [${KEY}] is not within the range of valid values. This value must be greater than or equal to zero.`;
+      return CheckCatalogService.formatResultMessage('LINEAR-17-B', {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   meanReferenceValue: number;
@@ -63,12 +80,19 @@ export class LinearitySummaryBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-18-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @IsNotNegative({
     message: (args: ValidationArguments) => {
-      return `The value [${args.value}] in the field [${args.property}] for [${KEY}] is not within the range of valid values. This value must be greater than or equal to zero.`;
+      return CheckCatalogService.formatResultMessage('LINEAR-18-B', {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   percentError: number;
@@ -78,7 +102,10 @@ export class LinearitySummaryBaseDTO {
   )
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('LINEAR-37-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   apsIndicator: number;


### PR DESCRIPTION
Placeholder to refactor all the checks for Linearity Injection that resulted from [#4097](https://github.com/US-EPA-CAMD/easey-ui/issues/4097) for QA-Cert Api

Change how we get the error messages for linearity injection and linearity summary to use the check catalog service