### PR TITLE
✨ Feature/3059: API Endpoint - Add QA Test Extensions Exemptions Data

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -78,6 +78,7 @@ import { HgSummaryModule } from './hg-summary/hg-summary.module';
 import { HgInjectionModule } from './hg-injection/hg-injection.module';
 import { QaCertificationEventWorkshopModule } from './qa-certification-event-workshop/qa-certification-event-workshop.module';
 import { MonitorSystemWorkspaceModule } from './monitor-system-workspace/monitor-system-workspace.module';
+import { TestExtensionExemptionsWorkspaceModule } from './test-extension-exemptions-workspace/test-extension-exemptions-workspace.module';
 @Module({
   imports: [
     RouterModule.forRoutes(routes),
@@ -156,6 +157,7 @@ import { MonitorSystemWorkspaceModule } from './monitor-system-workspace/monitor
     HgSummaryModule,
     QaCertificationEventWorkshopModule,
     MonitorSystemWorkspaceModule,
+    TestExtensionExemptionsWorkspaceModule,
   ],
 })
 export class AppModule {}

--- a/src/dto/test-extension-exemption.dto.ts
+++ b/src/dto/test-extension-exemption.dto.ts
@@ -1,6 +1,116 @@
-export class TestExtensionExemptionBaseDTO {}
+import { ApiProperty } from '@nestjs/swagger';
+import { RequireOne } from '../pipes/require-one.pipe';
+import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
+import { IsInRange } from '@us-epa-camd/easey-common/pipes';
+import { IsNotEmpty, ValidateIf, ValidationArguments } from 'class-validator';
+import { YEAR_QUARTER_TEST_TYPE_CODES } from '../utilities/constants';
+import { IsValidCode } from '../pipes/is-valid-code.pipe';
+import { SpanScaleCode } from '../entities/span-scale-code.entity';
 
-export class TestExtensionExemptionRecordDTO extends TestExtensionExemptionBaseDTO {}
+const KEY = 'Test Extension Exemption';
+
+export class TestExtensionExemptionBaseDTO {
+  @ApiProperty({
+    description: 'Stack Pipe Identifier. ADD TO PROPERTY METADATA',
+  })
+  @RequireOne('unitId', {
+    message:
+      'A Unit or Stack Pipe identifier (NOT both) must be provided for each Test Summary.',
+  })
+  stackPipeId?: string;
+
+  @ApiProperty({
+    description: propertyMetadata.unitId.description,
+  })
+  unitId?: string;
+
+  @ApiProperty({
+    description: propertyMetadata.year.description,
+  })
+  @IsInRange(1993, new Date().getFullYear(), {
+    message: (args: ValidationArguments) => {
+      return `Year must be greater than or equal to 1993 and less than or equal to ${new Date().getFullYear()}. You reported an invalid year of [${
+        args.value
+      }] in Test Summary record for Unit/Stack [${
+        args.object['unitId']
+          ? args.object['unitId']
+          : args.object['stackPipeId']
+      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+        args.object['testNumber']
+      }]`;
+    },
+  })
+  @ValidateIf(o => YEAR_QUARTER_TEST_TYPE_CODES.includes(o.testTypeCode))
+  year: number;
+
+  @ApiProperty({
+    description: propertyMetadata.quarter.description,
+  })
+  @IsInRange(1, 4, {
+    message: (args: ValidationArguments) => {
+      return `Quarter must be a numeric number from 1 to 4. You reported an invalid quarter of [${
+        args.value
+      }] in Test Summary record for Unit/Stack [${
+        args.object['unitId']
+          ? args.object['unitId']
+          : args.object['stackPipeId']
+      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+        args.object['testNumber']
+      }]`;
+    },
+  })
+  @ValidateIf(o => YEAR_QUARTER_TEST_TYPE_CODES.includes(o.testTypeCode))
+  quarter: number;
+
+  @ApiProperty({
+    description: propertyMetadata.monitorSystemDTOId.description,
+  })
+  monitoringSystemID?: string;
+
+  @ApiProperty({
+    description: propertyMetadata.componentDTOComponentId.description,
+  })
+  componentID?: string;
+
+  hoursUsed?: number;
+
+  @ApiProperty({
+    description: propertyMetadata.monitorSpanDTOSpanScaleCode.description,
+  })
+  @IsValidCode(SpanScaleCode, {
+    message: (args: ValidationArguments) => {
+      return `You reported an invalid Span Scale Code of [${
+        args.value
+      }] in Test Summary record for Unit/Stack [${
+        args.object['unitId']
+          ? args.object['unitId']
+          : args.object['stackPipeId']
+      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+        args.object['testNumber']
+      }]`;
+    },
+  })
+  spanScaleCode?: string;
+
+  fuelCode?: string;
+  extensionOrExemptionCode: string;
+}
+
+export class TestExtensionExemptionRecordDTO extends TestExtensionExemptionBaseDTO {
+  id: string;
+  locationId: string;
+
+  reportPeriodId: number;
+  checkSessionId: string;
+  submissionId: string;
+  submissionAvailabilityCode: string;
+  pendingStatusCode: string;
+  evalStatusCode: string;
+
+  userId: string;
+  addDate: string;
+  updateDate: string;
+}
 
 export class TestExtensionExemptionImportDTO extends TestExtensionExemptionBaseDTO {}
 

--- a/src/dto/test-extension-exemption.dto.ts
+++ b/src/dto/test-extension-exemption.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { RequireOne } from '../pipes/require-one.pipe';
 import { propertyMetadata } from '@us-epa-camd/easey-common/constants';
 import { IsInRange } from '@us-epa-camd/easey-common/pipes';
-import { IsNotEmpty, ValidateIf, ValidationArguments } from 'class-validator';
+import { ValidateIf, ValidationArguments } from 'class-validator';
 import { YEAR_QUARTER_TEST_TYPE_CODES } from '../utilities/constants';
 import { IsValidCode } from '../pipes/is-valid-code.pipe';
 import { SpanScaleCode } from '../entities/span-scale-code.entity';

--- a/src/entities/test-extension-exemption.entity.ts
+++ b/src/entities/test-extension-exemption.entity.ts
@@ -1,0 +1,144 @@
+import {
+  BaseEntity,
+  Entity,
+  Column,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+
+import { Component } from './component.entity';
+import { MonitorSystem } from './monitor-system.entity';
+import { ReportingPeriod } from './reporting-period.entity';
+import { MonitorLocation } from './monitor-location.entity';
+
+@Entity({ name: 'camdecmps.test_extension_exemption' })
+export class TestExtensionExemption extends BaseEntity {
+  @PrimaryColumn({
+    name: 'test_extension_exemption_id',
+  })
+  id: string;
+
+  @Column({
+    name: 'mon_loc_id',
+  })
+  locationId: string;
+
+  @Column({
+    name: 'rpt_period_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  reportPeriodId: number;
+
+  @Column({
+    name: 'mon_sys_id',
+  })
+  monitoringSystemRecordId: string;
+
+  @Column({
+    name: 'component_id',
+  })
+  componentRecordId: string;
+
+  @Column({
+    name: 'fuel_cd',
+  })
+  fuelCode: string;
+
+  @Column({
+    name: 'extens_exempt_cd',
+  })
+  extensionOrExemptionCode: string;
+
+  @Column({
+    type: 'date',
+    name: 'last_updated',
+  })
+  lastUpdated: Date;
+
+  @Column({ name: 'updated_status_flg' })
+  updatedStatusFlag: string;
+
+  @Column({ name: 'needs_eval_flg' })
+  needsEvalFlag: string;
+
+  @Column({ name: 'chk_session_id' })
+  checkSessionId: string;
+
+  @Column({
+    name: 'hours_used',
+    transformer: new NumericColumnTransformer(),
+  })
+  hoursUsed: number;
+
+  @Column({ name: 'userid' })
+  userId: string;
+
+  @Column({
+    type: 'date',
+    name: 'add_date',
+  })
+  addDate: Date;
+
+  @Column({
+    type: 'date',
+    name: 'update_date',
+  })
+  updateDate: Date;
+
+  @Column({
+    name: 'span_scale_cd',
+  })
+  spanScaleCode: string;
+
+  @Column({
+    name: 'submission_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  submissionId: string;
+
+  @Column({
+    name: 'submission_availability_cd',
+  })
+  submissionAvailabilityCode: string;
+
+  @Column({
+    name: 'pending_status_cd',
+  })
+  pendingStatusCode: string;
+
+  @Column({
+    name: 'eval_status_cd',
+  })
+  evalStatusCode: string;
+
+  @ManyToOne(
+    () => MonitorLocation,
+    ml => ml.testSummaries,
+  )
+  @JoinColumn({ name: 'mon_loc_id' })
+  location: MonitorLocation;
+
+  @ManyToOne(
+    () => Component,
+    c => c.testSummaries,
+  )
+  @JoinColumn({ name: 'component_id' })
+  component: Component;
+
+  @ManyToOne(
+    () => MonitorSystem,
+    ms => ms.testSummaries,
+  )
+  @JoinColumn({ name: 'mon_sys_id' })
+  system: MonitorSystem;
+
+  @ManyToOne(
+    () => ReportingPeriod,
+    rp => rp.testSummaries,
+  )
+  @JoinColumn({ name: 'rpt_period_id' })
+  reportingPeriod: ReportingPeriod;
+}

--- a/src/entities/test-summary.entity.ts
+++ b/src/entities/test-summary.entity.ts
@@ -47,7 +47,7 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'mon_sys_id',
   })
-  monitoringSystemID: string;
+  monitoringSystemRecordId: string;
 
   @Column({
     name: 'component_id',

--- a/src/entities/workspace/test-extension-exemption.entity.ts
+++ b/src/entities/workspace/test-extension-exemption.entity.ts
@@ -1,0 +1,144 @@
+import {
+  BaseEntity,
+  Entity,
+  Column,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
+
+import { Component } from './component.entity';
+import { MonitorSystem } from './monitor-system.entity';
+import { ReportingPeriod } from './reporting-period.entity';
+import { MonitorLocation } from './monitor-location.entity';
+
+@Entity({ name: 'camdecmpswks.test_extension_exemption' })
+export class TestExtensionExemption extends BaseEntity {
+  @PrimaryColumn({
+    name: 'test_extension_exemption_id',
+  })
+  id: string;
+
+  @Column({
+    name: 'mon_loc_id',
+  })
+  locationId: string;
+
+  @Column({
+    name: 'rpt_period_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  reportPeriodId: number;
+
+  @Column({
+    name: 'mon_sys_id',
+  })
+  monitoringSystemRecordId: string;
+
+  @Column({
+    name: 'component_id',
+  })
+  componentRecordId: string;
+
+  @Column({
+    name: 'fuel_cd',
+  })
+  fuelCode: string;
+
+  @Column({
+    name: 'extens_exempt_cd',
+  })
+  extensionOrExemptionCode: string;
+
+  @Column({
+    type: 'date',
+    name: 'last_updated',
+  })
+  lastUpdated: Date;
+
+  @Column({ name: 'updated_status_flg' })
+  updatedStatusFlag: string;
+
+  @Column({ name: 'needs_eval_flg' })
+  needsEvalFlag: string;
+
+  @Column({ name: 'chk_session_id' })
+  checkSessionId: string;
+
+  @Column({
+    name: 'hours_used',
+    transformer: new NumericColumnTransformer(),
+  })
+  hoursUsed: number;
+
+  @Column({ name: 'userid' })
+  userId: string;
+
+  @Column({
+    type: 'date',
+    name: 'add_date',
+  })
+  addDate: Date;
+
+  @Column({
+    type: 'date',
+    name: 'update_date',
+  })
+  updateDate: Date;
+
+  @Column({
+    name: 'span_scale_cd',
+  })
+  spanScaleCode: string;
+
+  @Column({
+    name: 'submission_id',
+    transformer: new NumericColumnTransformer(),
+  })
+  submissionId: string;
+
+  @Column({
+    name: 'submission_availability_cd',
+  })
+  submissionAvailabilityCode: string;
+
+  @Column({
+    name: 'pending_status_cd',
+  })
+  pendingStatusCode: string;
+
+  @Column({
+    name: 'eval_status_cd',
+  })
+  evalStatusCode: string;
+
+  @ManyToOne(
+    () => MonitorLocation,
+    ml => ml.testSummaries,
+  )
+  @JoinColumn({ name: 'mon_loc_id' })
+  location: MonitorLocation;
+
+  @ManyToOne(
+    () => Component,
+    c => c.testSummaries,
+  )
+  @JoinColumn({ name: 'component_id' })
+  component: Component;
+
+  @ManyToOne(
+    () => MonitorSystem,
+    ms => ms.testSummaries,
+  )
+  @JoinColumn({ name: 'mon_sys_id' })
+  system: MonitorSystem;
+
+  @ManyToOne(
+    () => ReportingPeriod,
+    rp => rp.testSummaries,
+  )
+  @JoinColumn({ name: 'rpt_period_id' })
+  reportingPeriod: ReportingPeriod;
+}

--- a/src/entities/workspace/test-summary.entity.ts
+++ b/src/entities/workspace/test-summary.entity.ts
@@ -47,7 +47,7 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'mon_sys_id',
   })
-  monitoringSystemID: string;
+  monitoringSystemRecordId: string;
 
   @Column({
     name: 'component_id',

--- a/src/maps/test-extension-exemption.map.spec.ts
+++ b/src/maps/test-extension-exemption.map.spec.ts
@@ -1,0 +1,84 @@
+import { TestExtensionExemptionMap } from './test-extension-exemption.map';
+import { TestExtensionExemption } from '../entities/test-extension-exemption.entity';
+import { MonitorLocation } from '../entities/monitor-location.entity';
+import { StackPipe } from '../entities/stack-pipe.entity';
+import { Unit } from '../entities/unit.entity';
+import { ReportingPeriod } from '../entities/reporting-period.entity';
+import { MonitorSystem } from '../entities/monitor-system.entity';
+import { Component } from '../entities/component.entity';
+
+const string = '';
+const number = 0;
+const date = new Date();
+
+const entity = new TestExtensionExemption();
+entity.id = string;
+entity.location = new MonitorLocation();
+entity.location.id = string;
+entity.location.stackPipe = new StackPipe();
+entity.location.stackPipe.name = string;
+entity.location.unit = new Unit();
+entity.location.unit.name = string;
+entity.reportingPeriod = new ReportingPeriod();
+entity.reportingPeriod.year = number;
+entity.reportingPeriod.quarter = number;
+entity.system = new MonitorSystem();
+entity.system.monitoringSystemID = string;
+entity.component = new Component();
+entity.component.componentID = string;
+entity.hoursUsed = number;
+entity.spanScaleCode = string;
+entity.fuelCode = string;
+entity.extensionOrExemptionCode = string;
+entity.reportPeriodId = number;
+entity.checkSessionId = string;
+entity.submissionId = string;
+entity.submissionAvailabilityCode = string;
+entity.pendingStatusCode = string;
+entity.evalStatusCode = string;
+entity.userId = string;
+entity.addDate = date;
+entity.updateDate = date;
+
+describe('TestExtensionExemptionMap', () => {
+  it('maps an entity to a dto', async () => {
+    const map = new TestExtensionExemptionMap();
+    const result = await map.one(entity);
+    expect(result.id).toEqual(string);
+    expect(result.locationId).toEqual(string);
+    expect(result.stackPipeId).toEqual(string);
+    expect(result.unitId).toEqual(string);
+    expect(result.year).toEqual(number);
+    expect(result.quarter).toEqual(number);
+    expect(result.monitoringSystemID).toEqual(string);
+    expect(result.componentID).toEqual(string);
+    expect(result.hoursUsed).toEqual(number);
+    expect(result.spanScaleCode).toEqual(string);
+    expect(result.fuelCode).toEqual(string);
+    expect(result.extensionOrExemptionCode).toEqual(string);
+    expect(result.reportPeriodId).toEqual(number);
+    expect(result.checkSessionId).toEqual(string);
+    expect(result.submissionId).toEqual(string);
+    expect(result.submissionAvailabilityCode).toEqual(string);
+    // expect(result.pendingStatusCode).toEqual(string);
+    // expect(result.evalStatusCode).toEqual(string);
+    expect(result.userId).toEqual(string);
+    expect(result.addDate).toEqual(date.toLocaleString());
+    expect(result.updateDate).toEqual(date.toLocaleString());
+  });
+
+  it('should return null when addDate, updateDate, pendingStatusCode and evalStatusCode is undefined', async () => {
+    entity.addDate = undefined;
+    entity.updateDate = undefined;
+    entity.pendingStatusCode = undefined;
+    entity.evalStatusCode = undefined;
+
+    const map = new TestExtensionExemptionMap();
+    const result = await map.one(entity);
+
+    expect(result.pendingStatusCode).toEqual(null);
+    expect(result.evalStatusCode).toEqual(null);
+    expect(result.addDate).toEqual(null);
+    expect(result.updateDate).toEqual(null);
+  });
+});

--- a/src/maps/test-extension-exemption.map.ts
+++ b/src/maps/test-extension-exemption.map.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { BaseMap } from '@us-epa-camd/easey-common/maps';
+import { TestExtensionExemptionDTO } from '../dto/test-extension-exemption.dto';
+import { TestExtensionExemption } from '../entities/test-extension-exemption.entity';
+
+@Injectable()
+export class TestExtensionExemptionMap extends BaseMap<
+  TestExtensionExemption,
+  TestExtensionExemptionDTO
+> {
+  public async one(
+    entity: TestExtensionExemption,
+  ): Promise<TestExtensionExemptionDTO> {
+    return {
+      id: entity.id,
+      locationId: entity.location.id,
+      stackPipeId:
+        entity.location && entity.location.stackPipe
+          ? entity.location.stackPipe.name
+          : null,
+      unitId:
+        entity.location && entity.location.unit
+          ? entity.location.unit.name
+          : null,
+      year: entity.reportingPeriod ? entity.reportingPeriod.year : null,
+      quarter: entity.reportingPeriod ? entity.reportingPeriod.quarter : null,
+      monitoringSystemID: entity.system
+        ? entity.system.monitoringSystemID
+        : null,
+      componentID: entity.component ? entity.component.componentID : null,
+      hoursUsed: entity.hoursUsed,
+      spanScaleCode: entity.spanScaleCode,
+      fuelCode: entity.fuelCode,
+      extensionOrExemptionCode: entity.extensionOrExemptionCode,
+      reportPeriodId: entity.reportPeriodId,
+      checkSessionId: entity.checkSessionId,
+      submissionId: entity.submissionId,
+      submissionAvailabilityCode: entity.submissionAvailabilityCode,
+      pendingStatusCode: entity.pendingStatusCode
+        ? entity.pendingStatusCode
+        : null,
+      evalStatusCode: entity.evalStatusCode ? entity.evalStatusCode : null,
+      userId: entity.userId,
+      addDate: entity.addDate ? entity.addDate.toLocaleString() : null,
+      updateDate: entity.updateDate ? entity.updateDate.toLocaleString() : null,
+    };
+  }
+}

--- a/src/qa-certification/qa-certification.service.spec.ts
+++ b/src/qa-certification/qa-certification.service.spec.ts
@@ -31,7 +31,13 @@ describe('QA Certification Service', () => {
   describe('export test', () => {
     it('successfully calls export() service function', async () => {
       const paramsDTO = new QACertificationParamsDTO();
-      const expected = { testSummaryData: [] };
+      paramsDTO.facilityId = 1;
+      const expected = {
+        orisCode: 1,
+        certificationEventData: undefined,
+        testExtensionExemptionData: undefined,
+        testSummaryData: [],
+      };
       testSummaryService.export.mockResolvedValue([]);
       const result = await service.export(paramsDTO);
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -64,6 +64,7 @@ import { HgInjectionWorkspaceModule } from './hg-injection-workspace/hg-injectio
 import { HgSummaryModule } from './hg-summary/hg-summary.module';
 import { HgInjectionModule } from './hg-injection/hg-injection.module';
 import { QaCertificationEventWorkshopModule } from './qa-certification-event-workshop/qa-certification-event-workshop.module';
+import { TestExtensionExemptionsWorkspaceModule } from './test-extension-exemptions-workspace/test-extension-exemptions-workspace.module';
 
 const routes: Routes = [
   {
@@ -367,6 +368,10 @@ const routes: Routes = [
             module: TransmitterTransducerAccuracyWorkspaceModule,
           },
         ],
+      },
+      {
+        path: ':locId/test-extension-exemptions',
+        module: TestExtensionExemptionsWorkspaceModule,
       },
     ],
   },

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.spec.ts
@@ -2,21 +2,66 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TestExtensionExemptionsWorkspaceController } from './test-extension-exemptions-workspace.controller';
 import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
 
+import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import { HttpModule } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import {
+  TestExtensionExemptionBaseDTO,
+  TestExtensionExemptionRecordDTO,
+} from '../dto/test-extension-exemption.dto';
+
+const user: CurrentUser = {
+  userId: 'testUser',
+  sessionId: '',
+  expiration: '',
+  clientIp: '',
+  isAdmin: false,
+  roles: [],
+};
+
+const testExtExp = new TestExtensionExemptionRecordDTO();
+
+const payload = new TestExtensionExemptionBaseDTO();
+
+const mockTestExtensionExemptionWorkspaceService = () => ({
+  createTestExtensionExemption: jest.fn().mockResolvedValue(testExtExp),
+});
+
 describe('TestExtensionExemptionsWorkspaceController', () => {
   let controller: TestExtensionExemptionsWorkspaceController;
+  let service: TestExtensionExemptionsWorkspaceService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
       controllers: [TestExtensionExemptionsWorkspaceController],
-      providers: [TestExtensionExemptionsWorkspaceService],
+      providers: [
+        ConfigService,
+        AuthGuard,
+
+        {
+          provide: TestExtensionExemptionsWorkspaceService,
+          useFactory: mockTestExtensionExemptionWorkspaceService,
+        },
+      ],
     }).compile();
 
     controller = module.get<TestExtensionExemptionsWorkspaceController>(
       TestExtensionExemptionsWorkspaceController,
     );
+    service = module.get(TestExtensionExemptionsWorkspaceService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('createTestExtensionExemption', () => {
+    it('should create test summary record', async () => {
+      const spyService = jest.spyOn(service, 'createTestExtensionExemption');
+      const result = await controller.createTestExtensionExemption(
+        '1',
+        payload,
+        user,
+      );
+      expect(result).toEqual(testExtExp);
+    });
   });
 });

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestExtensionExemptionsWorkspaceController } from './test-extension-exemptions-workspace.controller';
+import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+
+describe('TestExtensionExemptionsWorkspaceController', () => {
+  let controller: TestExtensionExemptionsWorkspaceController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestExtensionExemptionsWorkspaceController],
+      providers: [TestExtensionExemptionsWorkspaceService],
+    }).compile();
+
+    controller = module.get<TestExtensionExemptionsWorkspaceController>(
+      TestExtensionExemptionsWorkspaceController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
@@ -11,7 +11,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import {
   TestExtensionExemptionBaseDTO,
   TestExtensionExemptionRecordDTO,
-} from 'src/dto/test-extension-exemption.dto';
+} from '../dto/test-extension-exemption.dto';
 import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
 
 @Controller()

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCreatedResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { User } from '@us-epa-camd/easey-common/decorators';
+import { AuthGuard } from '@us-epa-camd/easey-common/guards';
+import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
+import {
+  TestExtensionExemptionBaseDTO,
+  TestExtensionExemptionRecordDTO,
+} from 'src/dto/test-extension-exemption.dto';
+import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+
+@Controller()
+@ApiSecurity('APIKey')
+@ApiTags('Test Extension Exemption')
+export class TestExtensionExemptionsWorkspaceController {
+  constructor(
+    private readonly service: TestExtensionExemptionsWorkspaceService,
+  ) {}
+
+  @Post()
+  @UseGuards(AuthGuard)
+  @ApiBearerAuth('Token')
+  @ApiCreatedResponse({
+    type: TestExtensionExemptionRecordDTO,
+    description: 'Creates a Test ExtensionExemption record in the workspace',
+  })
+  async createTestExtensionExemption(
+    @Param('locId') locationId: string,
+    @Body() payload: TestExtensionExemptionBaseDTO,
+    @User() user: CurrentUser,
+  ): Promise<TestExtensionExemptionRecordDTO> {
+    return this.service.createTestExtensionExemption(
+      locationId,
+      payload,
+      user.userId,
+    );
+  }
+}

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.module.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+import { TestExtensionExemptionsWorkspaceController } from './test-extension-exemptions-workspace.controller';
+import { HttpModule } from '@nestjs/axios';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TestExtensionExemptionsWorkspaceRepository } from './test-extension-exemptions-workspace.repository';
+import { TestExtensionExemptionMap } from '../maps/test-extension-exemption.map';
+import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
+import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
+import { ReportingPeriodRepository } from '../reporting-period/reporting-period.repository';
+import { MonitorLocationRepository } from '../monitor-location/monitor-location.repository';
+import { UnitRepository } from '../unit/unit.repository';
+import { StackPipeRepository } from '../stack-pipe/stack-pipe.repository';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      TestExtensionExemptionsWorkspaceRepository,
+      ComponentWorkspaceRepository,
+      MonitorSystemRepository,
+      ReportingPeriodRepository,
+      MonitorLocationRepository,
+      UnitRepository,
+      StackPipeRepository,
+    ]),
+    HttpModule,
+  ],
+  controllers: [TestExtensionExemptionsWorkspaceController],
+  providers: [
+    TestExtensionExemptionMap,
+    TestExtensionExemptionsWorkspaceService,
+  ],
+  exports: [
+    TypeOrmModule,
+    TestExtensionExemptionMap,
+    TestExtensionExemptionsWorkspaceService,
+  ],
+})
+export class TestExtensionExemptionsWorkspaceModule {}

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.spec.ts
@@ -1,0 +1,52 @@
+import { Test } from '@nestjs/testing';
+import { SelectQueryBuilder } from 'typeorm';
+import { TestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
+
+import * as testExtExpQueryBuilder from '../utilities/test-extension-exemption.querybuilder';
+import { TestExtensionExemptionsWorkspaceRepository } from './test-extension-exemptions-workspace.repository';
+
+const testExtExp = new TestExtensionExemption();
+
+const mockQueryBuilder = () => ({
+  where: jest.fn(),
+  andWhere: jest.fn(),
+  getOne: jest.fn(),
+  getMany: jest.fn(),
+  leftJoinAndSelect: jest.fn(),
+  leftJoin: jest.fn(),
+});
+
+describe('TestExtensionExemptionsWorkspaceRepository', () => {
+  let repository;
+  let queryBuilder;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        TestExtensionExemptionsWorkspaceRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    repository = module.get(TestExtensionExemptionsWorkspaceRepository);
+    queryBuilder = module.get<SelectQueryBuilder<TestExtensionExemption>>(
+      SelectQueryBuilder,
+    );
+
+    repository.createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
+    jest
+      .spyOn(testExtExpQueryBuilder, 'addJoins')
+      .mockReturnValue(queryBuilder);
+  });
+
+  describe('getTestExtensionExemptionById', () => {
+    it('calls buildBaseQuery and get one Test Extension Exemption from the repository with Id', async () => {
+      queryBuilder.where.mockReturnValue(queryBuilder);
+      queryBuilder.getOne.mockReturnValue(testExtExp);
+
+      const result = await repository.getTestExtensionExemptionById('1');
+
+      expect(result).toEqual(testExtExp);
+    });
+  });
+});

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
@@ -1,0 +1,22 @@
+import { addJoins } from 'src/utilities/test-extension-exemption.querybuilder';
+import { EntityRepository, Repository, SelectQueryBuilder } from 'typeorm';
+import { TestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
+
+@EntityRepository(TestExtensionExemption)
+export class TestExtensionExemptionsWorkspaceRepository extends Repository<
+  TestExtensionExemption
+> {
+  private buildBaseQuery(): SelectQueryBuilder<TestExtensionExemption> {
+    const query = this.createQueryBuilder('tee');
+    return addJoins(query) as SelectQueryBuilder<TestExtensionExemption>;
+  }
+
+  async getTestExtensionExemptionById(
+    testExtExpId: string,
+  ): Promise<TestExtensionExemption> {
+    const query = this.buildBaseQuery().where('tee.id = :testExtExpId', {
+      testExtExpId,
+    });
+    return query.getOne();
+  }
+}

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
@@ -1,4 +1,4 @@
-import { addJoins } from 'src/utilities/test-extension-exemption.querybuilder';
+import { addJoins } from '../utilities/test-extension-exemption.querybuilder';
 import { EntityRepository, Repository, SelectQueryBuilder } from 'typeorm';
 import { TestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
 

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+
+describe('TestExtensionExemptionsWorkspaceService', () => {
+  let service: TestExtensionExemptionsWorkspaceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestExtensionExemptionsWorkspaceService],
+    }).compile();
+
+    service = module.get<TestExtensionExemptionsWorkspaceService>(
+      TestExtensionExemptionsWorkspaceService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
@@ -1,20 +1,195 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
+import {
+  TestExtensionExemptionBaseDTO,
+  TestExtensionExemptionRecordDTO,
+} from '../dto/test-extension-exemption.dto';
+import { Component } from '../entities/workspace/component.entity';
+import { MonitorLocation } from '../entities/workspace/monitor-location.entity';
+import { MonitorSystem } from '../entities/workspace/monitor-system.entity';
+import { ReportingPeriod } from '../entities/workspace/reporting-period.entity';
+import { StackPipe } from '../entities/workspace/stack-pipe.entity';
+import { TestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
+import { Unit } from '../entities/workspace/unit.entity';
+import { TestExtensionExemptionMap } from '../maps/test-extension-exemption.map';
+import { MonitorLocationRepository } from '../monitor-location/monitor-location.repository';
+import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
+import { ReportingPeriodRepository } from '../reporting-period/reporting-period.repository';
+import { StackPipeRepository } from '../stack-pipe/stack-pipe.repository';
+import { UnitRepository } from '../unit/unit.repository';
+import { TestExtensionExemptionsWorkspaceRepository } from './test-extension-exemptions-workspace.repository';
 import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+
+const locationId = '121';
+const payload = new TestExtensionExemptionBaseDTO();
+payload.unitId = '1';
+payload.stackPipeId = '1';
+const userId = 'testuser';
+
+const unit = new Unit();
+unit.name = '1';
+const stackPipe = new StackPipe();
+stackPipe.name = '1';
+const rp = new ReportingPeriod();
+rp.id = 1;
+const ms = new MonitorSystem();
+ms.id = '1';
+const comp = new Component();
+comp.id = '1';
+
+const entity = new TestExtensionExemption();
+const dto = new TestExtensionExemptionRecordDTO();
+
+const mockRepository = () => ({
+  getTestExtensionExemptionById: jest.fn().mockResolvedValue(entity),
+  delete: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(entity),
+  create: jest.fn().mockResolvedValue(entity),
+  save: jest.fn().mockResolvedValue(entity),
+});
+
+const mockMap = () => ({
+  one: jest.fn().mockResolvedValue(dto),
+  many: jest.fn().mockResolvedValue([dto]),
+});
 
 describe('TestExtensionExemptionsWorkspaceService', () => {
   let service: TestExtensionExemptionsWorkspaceService;
+  let repository: TestExtensionExemptionsWorkspaceRepository;
+  let unitRepository: UnitRepository;
+  let stackPipeRepository: StackPipeRepository;
+  let locationRepository: MonitorLocationRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TestExtensionExemptionsWorkspaceService],
+      providers: [
+        TestExtensionExemptionsWorkspaceService,
+        {
+          provide: TestExtensionExemptionMap,
+          useFactory: mockMap,
+        },
+        {
+          provide: TestExtensionExemptionsWorkspaceRepository,
+          useFactory: mockRepository,
+        },
+        {
+          provide: MonitorLocationRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(new MonitorLocation()),
+          }),
+        },
+        {
+          provide: UnitRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(unit),
+          }),
+        },
+        {
+          provide: StackPipeRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(stackPipe),
+          }),
+        },
+        {
+          provide: ReportingPeriodRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(rp),
+          }),
+        },
+        {
+          provide: MonitorSystemRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(ms),
+          }),
+        },
+        {
+          provide: ComponentWorkspaceRepository,
+          useFactory: () => ({
+            findOne: jest.fn().mockResolvedValue(comp),
+          }),
+        },
+      ],
     }).compile();
 
     service = module.get<TestExtensionExemptionsWorkspaceService>(
       TestExtensionExemptionsWorkspaceService,
     );
+    repository = module.get(TestExtensionExemptionsWorkspaceRepository);
+    unitRepository = module.get(UnitRepository);
+    stackPipeRepository = module.get(StackPipeRepository);
+    locationRepository = module.get(MonitorLocationRepository);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('createTestExtensionExemption', () => {
+    it('should call the createTestExtensionExemption and create test summariy', async () => {
+      jest.spyOn(service, 'lookupValues').mockResolvedValue([]);
+
+      jest
+        .spyOn(repository, 'getTestExtensionExemptionById')
+        .mockResolvedValue(entity);
+
+      const result = await service.createTestExtensionExemption(
+        locationId,
+        payload,
+        userId,
+      );
+
+      expect(result).toEqual(dto);
+    });
+
+    it('should call the createTestExtensionExemption and create test summariy with historicalRecordId', async () => {
+      jest.spyOn(service, 'lookupValues').mockResolvedValue([]);
+
+      jest
+        .spyOn(repository, 'getTestExtensionExemptionById')
+        .mockResolvedValue(entity);
+
+      const result = await service.createTestExtensionExemption(
+        locationId,
+        payload,
+        userId,
+        'historicalRecordId',
+      );
+
+      expect(result).toEqual(dto);
+    });
+
+    it('should call the createTestExtensionExemption and throw error if Unit does not match', async () => {
+      jest.spyOn(service, 'lookupValues').mockResolvedValue([]);
+
+      const pipe = new StackPipe();
+      pipe.name = '101';
+      const unit = new Unit();
+      unit.name = '101';
+      const loc = new MonitorLocation();
+      loc.unitId = '11';
+
+      jest.spyOn(unitRepository, 'findOne').mockResolvedValue(unit);
+      jest.spyOn(stackPipeRepository, 'findOne').mockResolvedValue(stackPipe);
+      jest.spyOn(locationRepository, 'findOne').mockResolvedValue(loc);
+
+      let errored = false;
+
+      try {
+        await service.createTestExtensionExemption(locationId, payload, userId);
+      } catch (err) {
+        errored = true;
+      }
+
+      expect(errored).toBe(true);
+    });
+  });
+
+  describe('lookupValues', () => {
+    it('should return reportPeriodId, componentRecordId, monitorSystemRecordId', async () => {
+      payload.year = 2022;
+      payload.quarter = 1;
+      payload.componentID = '1';
+      payload.monitoringSystemID = 'abc';
+
+      const result = await service.lookupValues(locationId, payload);
+
+      expect(result).toEqual([1, '1', '1']);
+    });
   });
 });

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
@@ -1,0 +1,141 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  TestExtensionExemptionBaseDTO,
+  TestExtensionExemptionRecordDTO,
+} from 'src/dto/test-extension-exemption.dto';
+import { TestExtensionExemptionMap } from '../maps/test-extension-exemption.map';
+import { TestExtensionExemptionsWorkspaceRepository } from './test-extension-exemptions-workspace.repository';
+import { v4 as uuid } from 'uuid';
+import { currentDateTime } from '../utilities/functions';
+import { UnitRepository } from '../unit/unit.repository';
+import { StackPipeRepository } from '../stack-pipe/stack-pipe.repository';
+import { MonitorLocationRepository } from '../monitor-location/monitor-location.repository';
+import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
+import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
+import { ReportingPeriodRepository } from '../reporting-period/reporting-period.repository';
+import { Unit } from './../entities/workspace/unit.entity';
+import { StackPipe } from './../entities/workspace/stack-pipe.entity';
+import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
+
+@Injectable()
+export class TestExtensionExemptionsWorkspaceService {
+  constructor(
+    private readonly map: TestExtensionExemptionMap,
+    @InjectRepository(TestExtensionExemptionsWorkspaceRepository)
+    private readonly repository: TestExtensionExemptionsWorkspaceRepository,
+    @InjectRepository(UnitRepository)
+    private readonly unitRepository: UnitRepository,
+    @InjectRepository(StackPipeRepository)
+    private readonly stackPipeRepository: StackPipeRepository,
+    @InjectRepository(MonitorLocationRepository)
+    private readonly monitorLocationRepository: MonitorLocationRepository,
+    @InjectRepository(ComponentWorkspaceRepository)
+    private readonly componentRepository: ComponentWorkspaceRepository,
+    @InjectRepository(MonitorSystemRepository)
+    private readonly monSysRepository: MonitorSystemRepository,
+    @InjectRepository(ReportingPeriodRepository)
+    private readonly reportingPeriodRepository: ReportingPeriodRepository,
+  ) {}
+
+  async createTestExtensionExemption(
+    locationId: string,
+    payload: TestExtensionExemptionBaseDTO,
+    userId: string,
+    historicalrecordId?: string,
+  ): Promise<TestExtensionExemptionRecordDTO> {
+    const timestamp = currentDateTime();
+    const [
+      reportPeriodId,
+      componentRecordId,
+      monitoringSystemRecordId,
+    ] = await this.lookupValues(locationId, payload);
+
+    // Swap the DTO 3-char System ID for the Actual UID of the Monitor System
+
+    const location = await this.monitorLocationRepository.findOne(locationId);
+
+    let unit: Unit;
+    let stackPipe: StackPipe;
+
+    if (location.unitId) {
+      unit = await this.unitRepository.findOne(location.unitId);
+    } else {
+      stackPipe = await this.stackPipeRepository.findOne(location.stackPipeId);
+    }
+
+    if (
+      (unit && payload.unitId !== unit.name) ||
+      (stackPipe && payload.stackPipeId !== stackPipe.name)
+    ) {
+      throw new LoggingException(
+        `The provided Location Id [${locationId}] does not match the provided Unit/Stack [${
+          payload.unitId ? payload.unitId : payload.stackPipeId
+        }]`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const entity = this.repository.create({
+      ...payload,
+      id: historicalrecordId ? historicalrecordId : uuid(),
+      locationId,
+      monitoringSystemRecordId,
+      componentRecordId,
+      reportPeriodId,
+      userId,
+      addDate: timestamp,
+      updateDate: timestamp,
+      lastUpdated: timestamp,
+      needsEvalFlag: 'Y',
+      updatedStatusFlag: 'Y',
+      evalStatusCode: 'EVAL',
+      pendingStatusCode: 'PENDING',
+    });
+
+    await this.repository.save(entity);
+    const result = await this.repository.getTestExtensionExemptionById(
+      entity.id,
+    );
+
+    return this.map.one(result);
+  }
+
+  async lookupValues(
+    locationId: string,
+    payload: TestExtensionExemptionBaseDTO,
+  ) {
+    let reportPeriodId = null;
+    let componentRecordId = null;
+    let monitoringSystemRecordId = null;
+
+    if (payload.year && payload.quarter) {
+      const rptPeriod = await this.reportingPeriodRepository.findOne({
+        year: payload.year,
+        quarter: payload.quarter,
+      });
+
+      reportPeriodId = rptPeriod ? rptPeriod.id : null;
+    }
+
+    if (payload.componentID) {
+      const component = await this.componentRepository.findOne({
+        locationId: locationId,
+        componentID: payload.componentID,
+      });
+
+      componentRecordId = component ? component.id : null;
+    }
+
+    if (payload.monitoringSystemID) {
+      const monitorSystem = await this.monSysRepository.findOne({
+        locationId: locationId,
+        monitoringSystemID: payload.monitoringSystemID,
+      });
+
+      monitoringSystemRecordId = monitorSystem ? monitorSystem.id : null;
+    }
+
+    return [reportPeriodId, componentRecordId, monitoringSystemRecordId];
+  }
+}

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
@@ -42,7 +42,7 @@ export class TestExtensionExemptionsWorkspaceService {
     locationId: string,
     payload: TestExtensionExemptionBaseDTO,
     userId: string,
-    historicalrecordId?: string,
+    historicalRecordId?: string,
   ): Promise<TestExtensionExemptionRecordDTO> {
     const timestamp = currentDateTime();
     const [
@@ -78,7 +78,7 @@ export class TestExtensionExemptionsWorkspaceService {
 
     const entity = this.repository.create({
       ...payload,
-      id: historicalrecordId ? historicalrecordId : uuid(),
+      id: historicalRecordId ? historicalRecordId : uuid(),
       locationId,
       monitoringSystemRecordId,
       componentRecordId,

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -469,7 +469,7 @@ describe('TestSummaryWorkspaceService', () => {
 
       const result = await service.lookupValues(locationId, payload);
 
-      expect(result).toEqual([1, '1', ms]);
+      expect(result).toEqual([1, '1', '1']);
     });
   });
 

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -726,11 +726,8 @@ export class TestSummaryWorkspaceService {
     const [
       reportPeriodId,
       componentRecordId,
-      monitorSystem,
+      monitoringSystemRecordId,
     ] = await this.lookupValues(locationId, payload);
-
-    // Swap the DTO 3-char System ID for the Actual UID of the Monitor System
-    payload.monitoringSystemID = monitorSystem?.id;
 
     const location = await this.monitorLocationRepository.findOne(locationId);
 
@@ -760,6 +757,7 @@ export class TestSummaryWorkspaceService {
       id: historicalrecordId ? historicalrecordId : uuid(),
       locationId,
       componentRecordId,
+      monitoringSystemRecordId,
       reportPeriodId,
       userId,
       addDate: timestamp,
@@ -815,11 +813,8 @@ export class TestSummaryWorkspaceService {
     const [
       reportPeriodId,
       componentRecordId,
-      monitorSystem,
+      monitoringSystemRecordId,
     ] = await this.lookupValues(locationId, payload);
-
-    // Swap the DTO 3-char System ID for the Actual UID of the Monitor System
-    payload.monitoringSystemID = monitorSystem?.id;
 
     entity.beginDate = payload.beginDate;
     entity.beginHour = payload.beginHour;
@@ -830,7 +825,7 @@ export class TestSummaryWorkspaceService {
     entity.componentRecordId = componentRecordId;
     entity.gracePeriodIndicator = payload.gracePeriodIndicator;
     entity.injectionProtocolCode = payload.injectionProtocolCode;
-    entity.monitoringSystemID = payload.monitoringSystemID;
+    entity.monitoringSystemRecordId = monitoringSystemRecordId;
     entity.reportPeriodId = reportPeriodId;
     entity.spanScaleCode = payload.spanScaleCode;
     entity.testComment = payload.testComment;
@@ -884,7 +879,7 @@ export class TestSummaryWorkspaceService {
   async lookupValues(locationId: string, payload: TestSummaryBaseDTO) {
     let reportPeriodId = null;
     let componentRecordId = null;
-    let monitorSystem = null;
+    let monitoringSystemRecordId = null;
 
     if (payload.year && payload.quarter) {
       const rptPeriod = await this.reportingPeriodRepository.findOne({
@@ -905,12 +900,13 @@ export class TestSummaryWorkspaceService {
     }
 
     if (payload.monitoringSystemID) {
-      monitorSystem = await this.monSysRepository.findOne({
+      const monitorSystem = await this.monSysRepository.findOne({
         locationId: locationId,
         monitoringSystemID: payload.monitoringSystemID,
       });
+      monitoringSystemRecordId = monitorSystem ? monitorSystem.id : null;
     }
 
-    return [reportPeriodId, componentRecordId, monitorSystem];
+    return [reportPeriodId, componentRecordId, monitoringSystemRecordId];
   }
 }

--- a/src/utilities/test-extension-exemption.querybuilder.ts
+++ b/src/utilities/test-extension-exemption.querybuilder.ts
@@ -1,0 +1,21 @@
+import { SelectQueryBuilder } from 'typeorm';
+import { TestExtensionExemption } from '../entities/test-extension-exemption.entity';
+import { TestExtensionExemption as WorkspaceTestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
+
+export const addJoins = (
+  query: SelectQueryBuilder<
+    TestExtensionExemption | WorkspaceTestExtensionExemption
+  >,
+): SelectQueryBuilder<
+  TestExtensionExemption | WorkspaceTestExtensionExemption
+> => {
+  return query
+    .innerJoinAndSelect('tee.location', 'ml')
+    .leftJoinAndSelect('tee.system', 'ms')
+    .leftJoinAndSelect('tee.component', 'c')
+    .leftJoinAndSelect('tee.reportingPeriod', 'rp')
+    .leftJoinAndSelect('ml.unit', 'u')
+    .leftJoin('u.plant', 'up')
+    .leftJoinAndSelect('ml.stackPipe', 'sp')
+    .leftJoin('sp.plant', 'spp');
+};


### PR DESCRIPTION
## [✨ Feature/3059: API Endpoint - Add QA Test Extensions Exemptions Data](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/3059)