### PR TITLE
🐛 Bug/4727: Monitoring SYS ID and Component ID not populating when Editing

### DIFF
--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.spec.ts
@@ -159,7 +159,9 @@ describe('TestExtensionExemptionsWorkspaceService', () => {
     });
 
     it('should throw error when Test Extension Exemption not found', async () => {
-      jest.spyOn(repository, 'findOne').mockResolvedValue(undefined);
+      jest
+        .spyOn(repository, 'getTestExtensionExemptionById')
+        .mockResolvedValue(undefined);
 
       let errored = false;
 

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
@@ -49,7 +49,7 @@ export class TestExtensionExemptionsWorkspaceService {
   async getTestExtensionExemptionById(
     id: string,
   ): Promise<TestExtensionExemptionRecordDTO> {
-    const result = await this.repository.findOne(id);
+    const result = await this.repository.getTestExtensionExemptionById(id);
 
     if (!result) {
       throw new LoggingException(


### PR DESCRIPTION
## 🐛 [Bug/4727: Monitoring SYS ID and Component ID not populating when Editing](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4727)