### PR TITLE
🐛 Bug/4819: use CheckCatalogService to return error messages

### DIFF
--- a/src/dto/app-e-correlation-test-run.dto.ts
+++ b/src/dto/app-e-correlation-test-run.dto.ts
@@ -9,6 +9,7 @@ import {
 import { ValidateNested, ValidationArguments } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes/is-iso-format.pipe';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
 const KEY = 'Appendix E Correlation Test Run';
 const DATE_FORMAT = 'YYYY-MM-DD';
@@ -22,7 +23,13 @@ export class AppECorrelationTestRunBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: Date;
@@ -31,7 +38,13 @@ export class AppECorrelationTestRunBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: Date;

--- a/src/dto/calibration-injection.dto.ts
+++ b/src/dto/calibration-injection.dto.ts
@@ -1,11 +1,40 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
+import { ValidationArguments } from 'class-validator';
+
 const KEY = 'Calibration Injection';
+const DATE_FORMAT = 'YYYY-MM-DD';
 
 export class CalibrationInjectionBaseDTO {
   onLineOffLineIndicator: number;
   upscaleGasLevelCode: string;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   zeroInjectionDate: Date;
   zeroInjectionHour: number;
   zeroInjectionMinute: number;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   upscaleInjectionDate: Date;
   upscaleInjectionHour: number;
   upscaleInjectionMinute: number;

--- a/src/dto/cycle-time-injection.dto.ts
+++ b/src/dto/cycle-time-injection.dto.ts
@@ -19,7 +19,13 @@ export class CycleTimeInjectionBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: Date;
@@ -28,7 +34,13 @@ export class CycleTimeInjectionBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: Date;

--- a/src/dto/fuel-flowmeter-accuracy.dto.ts
+++ b/src/dto/fuel-flowmeter-accuracy.dto.ts
@@ -1,9 +1,26 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
+import { ValidationArguments } from 'class-validator';
+
 const KEY = 'Fuel Flowmeter Accuracy';
+const DATE_FORMAT = 'YYYY-MM-DD';
 export class FuelFlowmeterAccuracyBaseDTO {
   accuracyTestMethodCode: string;
   lowFuelAccuracy: number;
   midFuelAccuracy: number;
   highFuelAccuracy: number;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   reinstallationDate: string;
   reinstallationHour: number;
 }

--- a/src/dto/hg-injection.dto.ts
+++ b/src/dto/hg-injection.dto.ts
@@ -1,6 +1,22 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
+import { ValidationArguments } from 'class-validator';
+
 const KEY = 'Hg Test Injection';
+const DATE_FORMAT = 'YYYY-MM-DD';
 
 export class HgInjectionBaseDTO {
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   injectionDate: Date;
   injectionHour: number;
   injectionMinute: number;

--- a/src/dto/online-offline-calibration.dto.ts
+++ b/src/dto/online-offline-calibration.dto.ts
@@ -1,5 +1,24 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
+import { ValidationArguments } from 'class-validator';
+
+const KEY = 'Online Offline Calibration';
+const DATE_FORMAT = 'YYYY-MM-DD';
+
 export class OnlineOfflineCalibrationBaseDTO {
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   onlineZeroInjectionDate: string;
+
   onlineZeroInjectionHour: number;
   onlineZeroCalibrationError: number;
   onlineZeroAPSIndicator: number;
@@ -7,18 +26,54 @@ export class OnlineOfflineCalibrationBaseDTO {
   onlineZeroReferenceValue: number;
   onlineUpscaleCalibrationError: number;
   onlineUpscaleAPSIndicator: number;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   onlineUpscaleInjectionDate: string;
   onlineUpscaleInjectionHour: number;
   onlineUpscaleMeasuredValue: number;
   onlineUpscaleReferenceValue: number;
   offlineZeroCalibrationError: number;
   offlineZeroAPSIndicator: number;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   offlineZeroInjectionDate: string;
   offlineZeroInjectionHour: number;
   offlineZeroMeasuredValue: number;
   offlineZeroReferenceValue: number;
   offlineUpscaleCalibrationError: number;
   offlineUpscaleAPSIndicator: number;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   offlineUpscaleInjectionDate: string;
   offlineUpscaleInjectionHour: number;
   offlineUpscaleMeasuredValue: number;

--- a/src/dto/protocol-gas.dto.ts
+++ b/src/dto/protocol-gas.dto.ts
@@ -1,11 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, ValidationArguments } from 'class-validator';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
-
-import { IsValidCode } from '../pipes/is-valid-code.pipe';
-import { GasTypeCode } from '../entities/workspace/gas-type-code.entity';
+import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 
 const KEY = 'Protocol Gas';
+const DATE_FORMAT = 'YYYY-MM-DD';
 
 export class ProtocolGasBaseDTO {
   gasLevelCode: string;
@@ -24,6 +23,18 @@ export class ProtocolGasBaseDTO {
   gasTypeCode: string;
   cylinderIdentifier: string;
   vendorIdentifier: string;
+
+  @IsIsoFormat({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   expirationDate: Date;
 }
 

--- a/src/dto/qa-certification-event.dto.ts
+++ b/src/dto/qa-certification-event.dto.ts
@@ -1,3 +1,4 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 import { ValidationArguments } from 'class-validator';
 
@@ -12,7 +13,13 @@ export class QACertificationEventBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   qaCertEventDate: Date;
@@ -21,7 +28,13 @@ export class QACertificationEventBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   conditionalBeginDate?: Date;
@@ -29,7 +42,13 @@ export class QACertificationEventBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   completionTestDate?: Date;

--- a/src/dto/qa-certification-params.dto.ts
+++ b/src/dto/qa-certification-params.dto.ts
@@ -16,6 +16,7 @@ import { IsValidCodes } from '../pipes/is-valid-codes.pipe';
 import { ValidationArguments } from 'class-validator';
 import { FindOneOptions, In } from 'typeorm';
 import { dataDictionary, getMetadata, MetadataKeys } from '../data-dictionary';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
 const MIN_DATE = '1993-01-01';
 const DATE_FORMAT = 'YYYY-MM-DD';
@@ -95,11 +96,20 @@ export class QACertificationParamsDTO {
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT}.`,
+        {
+          fieldname: args.property,
+        },
+      );
     },
   })
-  @IsInDateRange('1993-01-01', null, {
-    message: `Begin Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+  @IsInDateRange(MIN_DATE, null, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `Begin Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+      );
+    },
   })
   beginDate?: Date;
 
@@ -108,11 +118,20 @@ export class QACertificationParamsDTO {
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT}.`,
+        {
+          fieldname: args.property,
+        },
+      );
     },
   })
-  @IsInDateRange('1993-01-01', null, {
-    message: `End Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+  @IsInDateRange(MIN_DATE, null, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `End Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+      );
+    },
   })
   endDate?: Date;
 }

--- a/src/dto/rata-run.dto.ts
+++ b/src/dto/rata-run.dto.ts
@@ -55,7 +55,13 @@ export class RataRunBaseDTO {
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: Date;
@@ -106,7 +112,13 @@ export class RataRunBaseDTO {
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: Date;

--- a/src/dto/rata-traverse.dto.ts
+++ b/src/dto/rata-traverse.dto.ts
@@ -1,11 +1,6 @@
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsInRange } from '@us-epa-camd/easey-common/pipes';
-import {
-  IsEmpty,
-  IsNotEmpty,
-  ValidateIf,
-  ValidationArguments,
-} from 'class-validator';
+import { IsNotEmpty, ValidationArguments } from 'class-validator';
 import { PressureMeasureCode } from '../entities/workspace/pressure-measure-code.entity';
 import { IsValidCode } from '../pipes/is-valid-code.pipe';
 

--- a/src/dto/rata.dto.ts
+++ b/src/dto/rata.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { Type } from 'class-transformer';
 import {
   IsNotEmpty,
@@ -15,7 +16,10 @@ export class RataBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `[RATA-102-A] You did not provide [${args.property}], which is required for [${KEY}].`;
+      return CheckCatalogService.formatResultMessage('RATA-102-A', {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   numberOfLoadLevels: number;

--- a/src/dto/review-and-submit-test-summary.dto.ts
+++ b/src/dto/review-and-submit-test-summary.dto.ts
@@ -1,7 +1,9 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 import { ValidationArguments } from 'class-validator';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
+const KEY = 'Review And Submit Test Summary';
 
 export class ReviewAndSubmitTestSummaryDTO {
   orisCode: number;
@@ -22,14 +24,26 @@ export class ReviewAndSubmitTestSummaryDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: string;
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: string;

--- a/src/dto/test-qualification.dto.ts
+++ b/src/dto/test-qualification.dto.ts
@@ -35,7 +35,13 @@ export class TestQualificationBaseDTO {
   @ValidateIf(o => o.testClaimCode === 'SLC')
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: Date;
@@ -51,7 +57,13 @@ export class TestQualificationBaseDTO {
   @ValidateIf(o => o.testClaimCode === 'SLC')
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: Date;

--- a/src/dto/test-summary-params.dto.ts
+++ b/src/dto/test-summary-params.dto.ts
@@ -14,9 +14,11 @@ import { TestTypeCodes } from '../enums/test-type-code.enum';
 import { SystemTypeCode } from '../entities/system-type-code.entity';
 import { SystemTypeCodes } from '../enums/system-type-code.enum';
 import { dataDictionary, getMetadata, MetadataKeys } from '../data-dictionary';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
 const MIN_DATE = '1993-01-01';
 const DATE_FORMAT = 'YYYY-MM-DD';
+const KEY = 'Test Summary Params';
 
 export class TestSummaryParamsDTO {
   @ApiProperty({
@@ -64,15 +66,32 @@ export class TestSummaryParamsDTO {
     ).description,
   })
   @IsValidDate({
-    message: `Begin Date must be a valid date in the format of ${DATE_FORMAT}.`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `Begin Date must be a valid date in the format of ${DATE_FORMAT}. You reported an invalid date of [value]`,
+        {
+          value: args.value,
+        },
+      );
+    },
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
-  @IsInDateRange('1993-01-01', null, {
-    message: `Begin Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+  @IsInDateRange(MIN_DATE, null, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `Begin Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+      );
+    },
   })
   beginDate?: Date;
 
@@ -80,15 +99,32 @@ export class TestSummaryParamsDTO {
     description: propertyMetadata.endDate.description,
   })
   @IsValidDate({
-    message: `End Date must be a valid date in the format of ${DATE_FORMAT}.`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `End Date must be a valid date in the format of ${DATE_FORMAT}. You reported an invalid date of [value]`,
+        {
+          value: args.value,
+        },
+      );
+    },
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT}.`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
-  @IsInDateRange('1993-01-01', null, {
-    message: `End Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+  @IsInDateRange(MIN_DATE, null, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `End Date must be greater than or equal to ${MIN_DATE} and less than or equal to the current date.`,
+      );
+    },
   })
   endDate?: Date;
 }

--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -185,7 +185,13 @@ export class TestSummaryBaseDTO {
           resultCode = 'FF2LTST-13-A';
           break;
         default:
-          return `You did not provide [${args.property}], which is required for [${KEY}].`;
+          return CheckCatalogService.formatMessage(
+            `You did not provide [fieldname], which is required for [key].`,
+            {
+              fieldname: args.property,
+              key: KEY,
+            },
+          );
       }
       return CheckCatalogService.formatResultMessage(resultCode, {
         fieldname: args.property,
@@ -224,7 +230,13 @@ export class TestSummaryBaseDTO {
           resultCode = 'FFACC-12-A';
           break;
         default:
-          return `You did not provide [${args.property}], which is required for [${KEY}].`;
+          return CheckCatalogService.formatMessage(
+            `You did not provide [fieldname], which is required for [key].`,
+            {
+              fieldname: args.property,
+              key: KEY,
+            },
+          );
       }
       return CheckCatalogService.formatResultMessage(resultCode, {
         fieldname: args.property,

--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -262,7 +262,26 @@ export class TestSummaryBaseDTO {
     description: 'Test Number. ADD TO PROPERTY METADATA',
   })
   @IsNotEmpty({
-    message: `You did not provide [testNumber], which is required for [${KEY}].`,
+    message: (args: ValidationArguments) => {
+      let resultCode;
+      switch (args.object['testTypeCode']) {
+        case TestTypeCodes.RATA:
+          resultCode = 'TEST-13-A';
+          break;
+        default:
+          return CheckCatalogService.formatMessage(
+            `You did not provide [fieldname], which is required for [key].`,
+            {
+              fieldname: args.property,
+              key: KEY,
+            },
+          );
+      }
+      return CheckCatalogService.formatResultMessage(resultCode, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
   })
   testNumber: string;
 
@@ -271,12 +290,45 @@ export class TestSummaryBaseDTO {
   })
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
-      return `You did not provide [${args.property}], which is required for [${KEY}].`;
+      let resultCode;
+      switch (args.object['testTypeCode']) {
+        case TestTypeCodes.SEVENDAY:
+          resultCode = 'SEVNDAY-3-A';
+          break;
+        case TestTypeCodes.CYCLE:
+          resultCode = 'CYCLE-4-A';
+          break;
+        case TestTypeCodes.LINE:
+          resultCode = 'LINEAR-9-A';
+          break;
+        case TestTypeCodes.ONOFF:
+          resultCode = 'ONOFF-3-A';
+          break;
+        case TestTypeCodes.RATA:
+          resultCode = 'RATA-4-A';
+          break;
+        default:
+          return CheckCatalogService.formatResultMessage('TEST-17-A', {
+            fieldname: args.property,
+            key: KEY,
+          });
+      }
+      return CheckCatalogService.formatResultMessage(resultCode, {
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @IsValidCode(TestReasonCode, {
     message: (args: ValidationArguments) => {
-      return `You reported the value [${args.value}], which is not in the list of valid values, in the field [${args.property}] for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported the value [value], which is not in the list of valid values, in the field [fieldname] for [key].`,
+        {
+          value: args.value,
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   @ValidateIf(o =>
@@ -329,7 +381,14 @@ export class TestSummaryBaseDTO {
           resultCode = 'ONOFF-39-B';
           break;
         default:
-          return `You reported the value [${args.value}], which is not in the list of valid values, in the field [testResultCode] for [Test Summary].`;
+          return CheckCatalogService.formatMessage(
+            `You reported the value [value], which is not in the list of valid values, in the field [fieldname] for [key].`,
+            {
+              value: args.value,
+              fieldname: args.property,
+              key: KEY,
+            },
+          );
       }
       return CheckCatalogService.formatResultMessage(resultCode, {
         value: args.value,
@@ -345,24 +404,42 @@ export class TestSummaryBaseDTO {
 
   @ApiProperty(getMetadata(dataDictionary.beginDate, MetadataKeys.TEST_SUMMARY))
   @IsNotEmpty({
-    message: `You did not provide [beginDate], which is required for [${KEY}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-1-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
   })
   @IsValidDate({
     message: (args: ValidationArguments) => {
-      return formatTestSummaryValidationError(
-        args,
-        `Begin Date must be a valid date in the format of ${DATE_FORMAT}. You reported an invalid date of [${args.value}]`,
+      return CheckCatalogService.formatMessage(
+        `Begin Date must be a valid date in the format of ${DATE_FORMAT}. You reported an invalid date of [value]`,
+        {
+          value: args.value,
+        },
       );
     },
   })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   @IsInDateRange(MIN_DATE, new Date(Date.now()).toISOString(), {
-    message: (args: ValidationArguments) =>
-      `You reported a [beginDate] of [${args.value}] which is outside the range of acceptable values for this date for [${KEY}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-1-B`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
   })
   @ValidateIf(o => BEGIN_DATE_TEST_TYPE_CODES.includes(o.testTypeCode))
   beginDate?: Date;
@@ -371,11 +448,23 @@ export class TestSummaryBaseDTO {
     description: 'Begin Hour. ADD TO PROPERTY METADATA',
   })
   @IsNotEmpty({
-    message: `You did not provide [beginHour], which is required for [${KEY}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-2-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
   })
   @IsInRange(MIN_HOUR, MAX_HOUR, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [beginHour] for [${KEY}] is not within the range of valid values from [${MIN_HOUR}] to [${MAX_HOUR}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-2-B`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+        minvalue: MIN_HOUR,
+        maxvalue: MAX_HOUR,
+      });
+    },
   })
   @ValidateIf(o => BEGIN_DATE_TEST_TYPE_CODES.includes(o.testTypeCode))
   beginHour?: number;
@@ -383,9 +472,24 @@ export class TestSummaryBaseDTO {
   @ApiProperty({
     description: 'Begin Minute. ADD TO PROPERTY METADATA',
   })
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-3-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsInRange(MIN_MINUTE, MAX_MINUTE, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [beginMinute] for [${KEY}] is not within the range of valid values from [${MIN_MINUTE}] to [${MAX_MINUTE}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-3-C`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+        minvalue: MIN_MINUTE,
+        maxvalue: MAX_MINUTE,
+      });
+    },
   })
   @ValidateIf(o => BEGIN_MINUTE_TEST_TYPE_CODES.includes(o.testTypeCode))
   beginMinute?: number;
@@ -396,17 +500,32 @@ export class TestSummaryBaseDTO {
   @IsValidDate({
     message: ErrorMessages.DateValidity(),
   })
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-4-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   @IsInDateRange(MIN_DATE, new Date(Date.now()).toISOString(), {
     message: (args: ValidationArguments) => {
-      args.object['locationId'] = args.object['unitId']
-        ? args.object['unitId']
-        : args.object['stackPipeId'];
-      return `You reported an invalid EndDate in the Test Summary record for Location [${args.object['locationId']}], TestTypeCode [${args.object['testTypeCode']}] and TestNumber [${args.object['testNumber']}].`;
+      return CheckCatalogService.formatResultMessage(`TEST-4-B`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
     },
   })
   @ValidateIf(o => VALID_CODES_FOR_END_DATE_VALIDATION.includes(o.testTypeCode))
@@ -416,11 +535,23 @@ export class TestSummaryBaseDTO {
     description: 'End Hour. ADD TO PROPERTY METADATA',
   })
   @IsInRange(MIN_HOUR, MAX_HOUR, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [endHour] for [${KEY}] is not within the range of valid values from [${MIN_HOUR}] to [${MAX_HOUR}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-5-B`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+        minvalue: MIN_HOUR,
+        maxvalue: MAX_HOUR,
+      });
+    },
   })
   @IsNotEmpty({
-    message: `You did not provide [endHour], which is required for [${KEY}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-5-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
   })
   @ValidateIf(o => VALID_CODES_FOR_END_DATE_VALIDATION.includes(o.testTypeCode))
   endHour?: number;
@@ -428,9 +559,24 @@ export class TestSummaryBaseDTO {
   @ApiProperty({
     description: 'End Minute. ADD TO PROPERTY METADATA',
   })
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-6-A`, {
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsInRange(MIN_MINUTE, MAX_MINUTE, {
-    message: (args: ValidationArguments) =>
-      `The value [${args.value}] in the field [endMinute] for [${KEY}] is not within the range of valid values from [${MIN_MINUTE}] to [${MAX_MINUTE}].`,
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage(`TEST-6-C`, {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+        minvalue: MIN_MINUTE,
+        maxvalue: MAX_MINUTE,
+      });
+    },
   })
   @ValidateIf(o =>
     VALID_CODES_FOR_END_MINUTE_VALIDATION.includes(o.testTypeCode),
@@ -442,15 +588,17 @@ export class TestSummaryBaseDTO {
   })
   @IsInRange(0, 1, {
     message: (args: ValidationArguments) => {
-      return `Grace Period Indicator must be a numeric number from 0 to 1. You reported an invalid value of [${
-        args.value
-      }] in Test Summary record for Unit/Stack [${
-        args.object['unitId']
-          ? args.object['unitId']
-          : args.object['stackPipeId']
-      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
-        args.object['testNumber']
-      }]`;
+      return CheckCatalogService.formatMessage(
+        `Grace Period Indicator must be a numeric number from 0 to 1. You reported an invalid value of [${
+          args.value
+        }] in Test Summary record for Unit/Stack [${
+          args.object['unitId']
+            ? args.object['unitId']
+            : args.object['stackPipeId']
+        }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+          args.object['testNumber']
+        }]`,
+      );
     },
   })
   @ValidateIf(o => GRACE_PERIOD_IND_TEST_TYPE_CODES.includes(o.testTypeCode))
@@ -461,15 +609,17 @@ export class TestSummaryBaseDTO {
   })
   @IsInRange(1993, new Date().getFullYear(), {
     message: (args: ValidationArguments) => {
-      return `Year must be greater than or equal to 1993 and less than or equal to ${new Date().getFullYear()}. You reported an invalid year of [${
-        args.value
-      }] in Test Summary record for Unit/Stack [${
-        args.object['unitId']
-          ? args.object['unitId']
-          : args.object['stackPipeId']
-      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
-        args.object['testNumber']
-      }]`;
+      return CheckCatalogService.formatMessage(
+        `Year must be greater than or equal to 1993 and less than or equal to ${new Date().getFullYear()}. You reported an invalid year of [${
+          args.value
+        }] in Test Summary record for Unit/Stack [${
+          args.object['unitId']
+            ? args.object['unitId']
+            : args.object['stackPipeId']
+        }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+          args.object['testNumber']
+        }]`,
+      );
     },
   })
   @ValidateIf(o => YEAR_QUARTER_TEST_TYPE_CODES.includes(o.testTypeCode))
@@ -480,15 +630,17 @@ export class TestSummaryBaseDTO {
   })
   @IsInRange(1, 4, {
     message: (args: ValidationArguments) => {
-      return `Quarter must be a numeric number from 1 to 4. You reported an invalid quarter of [${
-        args.value
-      }] in Test Summary record for Unit/Stack [${
-        args.object['unitId']
-          ? args.object['unitId']
-          : args.object['stackPipeId']
-      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
-        args.object['testNumber']
-      }]`;
+      return CheckCatalogService.formatMessage(
+        `Quarter must be a numeric number from 1 to 4. You reported an invalid quarter of [${
+          args.value
+        }] in Test Summary record for Unit/Stack [${
+          args.object['unitId']
+            ? args.object['unitId']
+            : args.object['stackPipeId']
+        }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+          args.object['testNumber']
+        }]`,
+      );
     },
   })
   @ValidateIf(o => YEAR_QUARTER_TEST_TYPE_CODES.includes(o.testTypeCode))
@@ -505,15 +657,17 @@ export class TestSummaryBaseDTO {
   })
   @IsValidCode(InjectionProtocolCode, {
     message: (args: ValidationArguments) => {
-      return `You reported an invalid Injection Protocol Code of [${
-        args.value
-      }] in Test Summary record for Unit/Stack [${
-        args.object['unitId']
-          ? args.object['unitId']
-          : args.object['stackPipeId']
-      }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
-        args.object['testNumber']
-      }]`;
+      return CheckCatalogService.formatMessage(
+        `You reported an invalid Injection Protocol Code of [${
+          args.value
+        }] in Test Summary record for Unit/Stack [${
+          args.object['unitId']
+            ? args.object['unitId']
+            : args.object['stackPipeId']
+        }], Test Type Code [${args.object['testTypeCode']}], and Test Number [${
+          args.object['testNumber']
+        }]`,
+      );
     },
   })
   @ValidateIf(o =>

--- a/src/dto/unit-default-test-run.dto.ts
+++ b/src/dto/unit-default-test-run.dto.ts
@@ -1,3 +1,4 @@
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes';
 import { ValidationArguments } from 'class-validator';
 
@@ -9,7 +10,13 @@ export class UnitDefaultTestRunBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   beginDate: Date;
@@ -18,7 +25,13 @@ export class UnitDefaultTestRunBaseDTO {
 
   @IsIsoFormat({
     message: (args: ValidationArguments) => {
-      return `You reported [${args.property}] which must be a valid ISO date format of ${DATE_FORMAT} for [${KEY}].`;
+      return CheckCatalogService.formatMessage(
+        `You reported [fieldname] which must be a valid ISO date format of ${DATE_FORMAT} for [key].`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
     },
   })
   endDate: Date;


### PR DESCRIPTION
## [🐛 Bug/4819: use CheckCatalogService to return error messages](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4819)
