### PR TITLE
Bug/4826 pei validation error

### DIFF
--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -990,8 +990,7 @@ export class TestSummaryChecksService {
       if (
         component &&
         component.componentTypeCode !== 'FLOW' &&
-        summary.testTypeCode !== TestTypeCodes.FFACC &&
-        summary.testTypeCode !== TestTypeCodes.FFACCTT
+        ![TestTypeCodes.FFACC.toString(), TestTypeCodes.FFACCTT.toString(), TestTypeCodes.PEI.toString()].includes(summary.testTypeCode)
       ) {
         if (summary.spanScaleCode === null) {
           return this.getMessage('TEST-8-A', {


### PR DESCRIPTION
When a user is adding Test Data for Primary Element Inspection (PEI), it displays a Span Scale Required validation which does not apply to PEI data