### PR TITLE
🐛 Bug/4992: cycle time injection properties returning string for number properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nestjs/platform-express": "^8.1.1",
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "8.0.3",
-    "@us-epa-camd/easey-common": "^15.1.3",
+    "@us-epa-camd/easey-common": "^15.2.0",
     "class-transformer": "0.4.0",
     "class-validator": "0.13.1",
     "dotenv": "^10.0.0",

--- a/src/entities/cycle-time-injection.entity.ts
+++ b/src/entities/cycle-time-injection.entity.ts
@@ -79,24 +79,28 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'injection_cycle_time',
+    transformer: new NumericColumnTransformer(),
   })
   injectionCycleTime: number;
 
   @Column({
     type: 'numeric',
     name: 'calc_injection_cycle_time',
+    transformer: new NumericColumnTransformer(),
   })
   calculatedInjectionCycleTime: number;
 
   @Column({
     type: 'numeric',
     name: 'begin_monitor_value',
+    transformer: new NumericColumnTransformer(),
   })
   beginMonitorValue: number;
 
   @Column({
     type: 'numeric',
     name: 'end_monitor_value',
+    transformer: new NumericColumnTransformer(),
   })
   endMonitorValue: number;
 

--- a/src/entities/cycle-time-injection.entity.ts
+++ b/src/entities/cycle-time-injection.entity.ts
@@ -1,3 +1,4 @@
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import {
   BaseEntity,
   Column,
@@ -31,6 +32,7 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'cal_gas_value',
+    transformer: new NumericColumnTransformer(),
   })
   calibrationGasValue: number;
 
@@ -43,12 +45,14 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'begin_hour',
+    transformer: new NumericColumnTransformer(),
   })
   beginHour: number;
 
   @Column({
     type: 'numeric',
     name: 'begin_min',
+    transformer: new NumericColumnTransformer(),
   })
   beginMinute: number;
 
@@ -61,12 +65,14 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
   })
   endHour: number;
 
   @Column({
     type: 'numeric',
     name: 'end_min',
+    transformer: new NumericColumnTransformer(),
   })
   endMinute: number;
 

--- a/src/entities/workspace/cycle-time-injection.entity.ts
+++ b/src/entities/workspace/cycle-time-injection.entity.ts
@@ -1,3 +1,4 @@
+import { NumericColumnTransformer } from '@us-epa-camd/easey-common/transforms';
 import {
   BaseEntity,
   Column,
@@ -31,6 +32,7 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'cal_gas_value',
+    transformer: new NumericColumnTransformer(),
   })
   calibrationGasValue: number;
 
@@ -43,12 +45,14 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'begin_hour',
+    transformer: new NumericColumnTransformer(),
   })
   beginHour: number;
 
   @Column({
     type: 'numeric',
     name: 'begin_min',
+    transformer: new NumericColumnTransformer(),
   })
   beginMinute: number;
 
@@ -61,36 +65,42 @@ export class CycleTimeInjection extends BaseEntity {
   @Column({
     type: 'numeric',
     name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
   })
   endHour: number;
 
   @Column({
     type: 'numeric',
     name: 'end_min',
+    transformer: new NumericColumnTransformer(),
   })
   endMinute: number;
 
   @Column({
     type: 'numeric',
     name: 'injection_cycle_time',
+    transformer: new NumericColumnTransformer(),
   })
   injectionCycleTime: number;
 
   @Column({
     type: 'numeric',
     name: 'calc_injection_cycle_time',
+    transformer: new NumericColumnTransformer(),
   })
   calculatedInjectionCycleTime: number;
 
   @Column({
     type: 'numeric',
     name: 'begin_monitor_value',
+    transformer: new NumericColumnTransformer(),
   })
   beginMonitorValue: number;
 
   @Column({
     type: 'numeric',
     name: 'end_monitor_value',
+    transformer: new NumericColumnTransformer(),
   })
   endMonitorValue: number;
 


### PR DESCRIPTION
## [#4992](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4992)