### PR TITLE
Bug/5016 app e run create

### DIFF
--- a/src/dto/app-e-correlation-test-run.dto.ts
+++ b/src/dto/app-e-correlation-test-run.dto.ts
@@ -10,11 +10,23 @@ import { ValidateNested, ValidationArguments } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsIsoFormat } from '@us-epa-camd/easey-common/pipes/is-iso-format.pipe';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
+import { IsInRange } from '@us-epa-camd/easey-common/pipes';
 
 const KEY = 'Appendix E Correlation Test Run';
 const DATE_FORMAT = 'YYYY-MM-DD';
 
 export class AppECorrelationTestRunBaseDTO {
+  @IsInRange(null, 99, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatMessage(
+        `The value for [fieldname] in [key] must not exceed 2 digits.`,
+        {
+          fieldname: args.property,
+          key: KEY,
+        },
+      );
+    },
+  })
   runNumber: number;
   referenceValue: number;
   hourlyHeatInputRate: number;


### PR DESCRIPTION
Issue:
When creating a Test Run Data record under Appendix E Correlation data, the system throws an internal server error. Looks like the Test Run Number isn't being saved

Steps to Reproduce:

Login to ECMPS
Access and checkout a Configuration for Test Data
From the Test Type Group dropdown, select Appendix E Correlation (Dolet Hills Power Station)
Expand the Test Data section and click Add for Appendix E Correlation Run data. Enter all the information needed and click Save and Close.

The issue is that the DB run number has a max length of 2