### PR TITLE
🐛 Bug/4993: Fuel Flowmeter Accuracy Historical Data Import not working

### DIFF
--- a/src/dto/fuel-flowmeter-accuracy.dto.ts
+++ b/src/dto/fuel-flowmeter-accuracy.dto.ts
@@ -21,7 +21,7 @@ export class FuelFlowmeterAccuracyBaseDTO {
       );
     },
   })
-  reinstallationDate: string;
+  reinstallationDate: Date;
   reinstallationHour: number;
 }
 

--- a/src/entities/fuel-flowmeter-accuracy.entity.ts
+++ b/src/entities/fuel-flowmeter-accuracy.entity.ts
@@ -30,10 +30,10 @@ export class FuelFlowmeterAccuracy extends BaseEntity {
   accuracyTestMethodCode: string;
 
   @Column({
-    type: 'timestamp',
+    type: 'date',
     name: 'reinstall_date',
   })
-  reinstallationDate: string;
+  reinstallationDate: Date;
 
   @Column({
     name: 'reinstall_hour',

--- a/src/entities/workspace/fuel-flowmeter-accuracy.entity.ts
+++ b/src/entities/workspace/fuel-flowmeter-accuracy.entity.ts
@@ -30,10 +30,10 @@ export class FuelFlowmeterAccuracy extends BaseEntity {
   accuracyTestMethodCode: string;
 
   @Column({
-    type: 'timestamp',
+    type: 'date',
     name: 'reinstall_date',
   })
-  reinstallationDate: string;
+  reinstallationDate: Date;
 
   @Column({
     name: 'reinstall_hour',

--- a/src/maps/fuel-flowmeter-accuracy.map.spec.ts
+++ b/src/maps/fuel-flowmeter-accuracy.map.spec.ts
@@ -10,7 +10,7 @@ entity.id = string;
 entity.testSumId = string;
 
 entity.accuracyTestMethodCode = string;
-entity.reinstallationDate = string;
+entity.reinstallationDate = date;
 entity.reinstallationHour = number;
 entity.lowFuelAccuracy = number;
 entity.midFuelAccuracy = number;
@@ -28,7 +28,7 @@ describe('FuelFlowmeterAccuracyMap', () => {
     expect(result.testSumId).toEqual(string);
 
     expect(result.accuracyTestMethodCode).toEqual(string);
-    expect(result.reinstallationDate).toEqual(string);
+    expect(result.reinstallationDate).toEqual(date);
     expect(result.reinstallationHour).toEqual(number);
     expect(result.lowFuelAccuracy).toEqual(number);
     expect(result.midFuelAccuracy).toEqual(number);


### PR DESCRIPTION
## [🐛 Bug/4993: Fuel Flowmeter Accuracy Historical Data Import not working](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/4993)
