### PR TITLE
Bug/5050 run number

### DIFF
--- a/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.ts
+++ b/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.ts
@@ -111,6 +111,7 @@ export class AppECorrelationTestRunWorkspaceService {
       );
     }
 
+    entity.runNumber = payload.runNumber;
     entity.referenceValue = payload.referenceValue;
     entity.hourlyHeatInputRate = payload.hourlyHeatInputRate;
     entity.totalHeatInput = payload.totalHeatInput;


### PR DESCRIPTION
When a user wishes to edit Appendix E Correlation Test Run Data, and makes updates to the Run Number the updates are not saved.

Steps to Recreate:

Login to ECMPS and access the QA Test Data Module
Select and checkout a Configuration and select Appendix E from the Test Type Group dropdown
Make sure it has data through Appendix E Correlation Run level
Update an existing Run Number and click Save and Close
Observe that it doesn't save the updates
