### PR TITLE
Bug/5055 aet creation error

### DIFF
--- a/src/dto/air-emission-test.dto.ts
+++ b/src/dto/air-emission-test.dto.ts
@@ -1,6 +1,6 @@
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { IsEmail } from '@us-epa-camd/easey-common/pipes';
-import { IsNotEmpty, IsString, ValidationArguments } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, MaxLength, ValidationArguments } from 'class-validator';
 
 const KEY = 'Air Emission Testing';
 
@@ -27,6 +27,15 @@ export class AirEmissionTestingBaseDTO {
   @IsString()
   qiFirstName: string;
 
+  @MaxLength(1, {
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('AETB-3-A', {
+        value: args.value,
+        fieldname: args.property,
+        key: KEY,
+      });
+    },
+  })
   @IsString()
   qiMiddleInitial: string;
 


### PR DESCRIPTION
Issue:
When a user wishes to create Air Emissions Testing data for Unit Default Test, upon Save and Close it is throwing an Internal Server Error

Steps to Recreate:

Login to ECMOS
Access the Test Data module, select and check out a Configuration
Select Unit Default from the Test Type Group dropdown, select an existing record and try adding AET data for it (Grand River Dam Authority)
Click Save and Close. You will observe that the system throws an Internal Server Error