### PR TITLE
🐛 Bug/5064: Unable to import historical App-E Heat Input from Gas and App-E Heat Input from Oil

### DIFF
--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
@@ -24,7 +24,9 @@ const mockTestSummaryService = () => ({
 });
 
 const mockHistoricalRepo = () => ({
-  findOne: jest.fn().mockResolvedValue(new AppEHeatInputFromGasRecordDTO()),
+  getAppEHeatInputFromGasByTestRunIdAndMonSysID: jest
+    .fn()
+    .mockResolvedValue(new AppEHeatInputFromGasRecordDTO()),
 });
 
 const appECorrTestRunId = 'd4e6f7';

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
@@ -175,10 +175,10 @@ export class AppEHeatInputFromGasWorkspaceService {
     let historicalRecord: AppEHeatInputFromGas;
 
     if (isHistoricalRecord) {
-      historicalRecord = await this.historicalRepo.findOne({
-        appECorrTestRunId: appECorrTestRunId,
-        monitoringSystemId: payload.monitoringSystemID,
-      });
+      historicalRecord = await this.historicalRepo.getAppEHeatInputFromGasByTestRunIdAndMonSysID(
+        appECorrTestRunId,
+        payload.monitoringSystemID,
+      );
     }
 
     const createdHeatInputFromGas = await this.createAppEHeatInputFromGas(

--- a/src/app-e-heat-input-from-gas/app-e-heat-input-from-gas.repository.spec.ts
+++ b/src/app-e-heat-input-from-gas/app-e-heat-input-from-gas.repository.spec.ts
@@ -7,6 +7,7 @@ const appEHeatInputFromGas = new AppEHeatInputFromGas();
 
 const mockQueryBuilder = () => ({
   where: jest.fn(),
+  andWhere: jest.fn(),
   getOne: jest.fn(),
   getMany: jest.fn(),
   leftJoinAndSelect: jest.fn(),
@@ -53,6 +54,22 @@ describe('AppEHeatInputFromGasRepository', () => {
       const result = await repository.getAppEHeatInputFromGasByTestRunId('1');
 
       expect(result).toEqual([appEHeatInputFromGas]);
+    });
+  });
+
+  describe('getAppEHeatInputFromGasByTestRunIdAndMonSysID', () => {
+    it('calls buildBaseQuery and get one Appendix E Heat Input From Oil from the repository with appECorrTestRunId', async () => {
+      queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);
+      queryBuilder.where.mockReturnValue(queryBuilder);
+      queryBuilder.andWhere.mockReturnValue(queryBuilder);
+      queryBuilder.getOne.mockReturnValue(appEHeatInputFromGas);
+
+      const result = await repository.getAppEHeatInputFromGasByTestRunIdAndMonSysID(
+        '1',
+        'AA0',
+      );
+
+      expect(result).toEqual(appEHeatInputFromGas);
     });
   });
 

--- a/src/app-e-heat-input-from-gas/app-e-heat-input-from-gas.repository.ts
+++ b/src/app-e-heat-input-from-gas/app-e-heat-input-from-gas.repository.ts
@@ -15,6 +15,22 @@ export class AppEHeatInputFromGasRepository extends Repository<
     return query.getOne();
   }
 
+  async getAppEHeatInputFromGasByTestRunIdAndMonSysID(
+    appECorrTestRunId: string,
+    monitoringSystemID: string,
+  ): Promise<AppEHeatInputFromGas> {
+    const query = this.createQueryBuilder('aehig')
+      .leftJoinAndSelect('aehig.system', 'ms')
+      .where('aehig.appECorrTestRunId = :appECorrTestRunId', {
+        appECorrTestRunId,
+      })
+      .andWhere('ms.monitoringSystemID = :monitoringSystemID', {
+        monitoringSystemID,
+      });
+
+    return query.getOne();
+  }
+
   async getAppEHeatInputFromGasByTestRunId(
     appECorrTestRunId: string,
   ): Promise<AppEHeatInputFromGas[]> {

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
@@ -51,7 +51,9 @@ const mockMap = () => ({
 });
 
 const mockHistoricalRepo = () => ({
-  findOne: jest.fn().mockResolvedValue(new AppEHeatInputFromGasRecordDTO()),
+  getAppEHeatInputFromOilByTestRunIdAndMonSysID: jest
+    .fn()
+    .mockResolvedValue(new AppEHeatInputFromGasRecordDTO()),
 });
 
 describe('AppEHeatInputOilWorkspaceService', () => {

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
@@ -183,10 +183,10 @@ export class AppEHeatInputFromOilWorkspaceService {
     let historicalRecord: AppEHeatInputFromOil;
 
     if (isHistoricalRecord) {
-      historicalRecord = await this.historicalRepo.findOne({
-        appECorrTestRunId: appECorrTestRunId,
-        monitoringSystemID: payload.monitoringSystemID,
-      });
+      historicalRecord = await this.historicalRepo.getAppEHeatInputFromOilByTestRunIdAndMonSysID(
+        appECorrTestRunId,
+        payload.monitoringSystemID,
+      );
     }
 
     const createdHeatInputFromOil = await this.createAppEHeatInputFromOilRecord(

--- a/src/app-e-heat-input-from-oil/app-e-heat-input-from-oil.repository.spec.ts
+++ b/src/app-e-heat-input-from-oil/app-e-heat-input-from-oil.repository.spec.ts
@@ -7,6 +7,7 @@ const appEHeatInputFromOil = new AppEHeatInputFromOil();
 
 const mockQueryBuilder = () => ({
   where: jest.fn(),
+  andWhere: jest.fn(),
   getOne: jest.fn(),
   getMany: jest.fn(),
   leftJoinAndSelect: jest.fn(),
@@ -53,6 +54,22 @@ describe('AppEHeatInputFromOilRepository', () => {
       const result = await repository.getAppEHeatInputFromOilsByTestRunId('1');
 
       expect(result).toEqual([appEHeatInputFromOil]);
+    });
+  });
+
+  describe('getAppEHeatInputFromOilByTestRunIdAndMonSysID', () => {
+    it('calls buildBaseQuery and get one Appendix E Heat Input From Oil from the repository with appECorrTestRunId', async () => {
+      queryBuilder.leftJoinAndSelect.mockReturnValue(queryBuilder);
+      queryBuilder.where.mockReturnValue(queryBuilder);
+      queryBuilder.andWhere.mockReturnValue(queryBuilder);
+      queryBuilder.getOne.mockReturnValue(appEHeatInputFromOil);
+
+      const result = await repository.getAppEHeatInputFromOilByTestRunIdAndMonSysID(
+        '1',
+        'AA0',
+      );
+
+      expect(result).toEqual(appEHeatInputFromOil);
     });
   });
 

--- a/src/app-e-heat-input-from-oil/app-e-heat-input-from-oil.repository.ts
+++ b/src/app-e-heat-input-from-oil/app-e-heat-input-from-oil.repository.ts
@@ -15,6 +15,22 @@ export class AppEHeatInputFromOilRepository extends Repository<
     return query.getOne();
   }
 
+  async getAppEHeatInputFromOilByTestRunIdAndMonSysID(
+    appECorrTestRunId: string,
+    monitoringSystemID: string,
+  ): Promise<AppEHeatInputFromOil> {
+    const query = this.createQueryBuilder('aehig')
+      .leftJoinAndSelect('aehig.system', 'ms')
+      .where('aehig.appECorrTestRunId = :appECorrTestRunId', {
+        appECorrTestRunId,
+      })
+      .andWhere('ms.monitoringSystemID = :monitoringSystemID', {
+        monitoringSystemID,
+      });
+
+    return query.getOne();
+  }
+
   async getAppEHeatInputFromOilsByTestRunId(
     appECorrTestRunId: string,
   ): Promise<AppEHeatInputFromOil[]> {


### PR DESCRIPTION
## [🐛 Bug/5064: Unable to import historical App-E Heat Input from Gas and App-E Heat Input from Oil](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/5064)