### PR TITLE
Bug/5059 test qual air ems import export

### DIFF
--- a/src/air-emission-testing-workspace/air-emission-testing-workspace.module.ts
+++ b/src/air-emission-testing-workspace/air-emission-testing-workspace.module.ts
@@ -7,11 +7,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
 import { AirEmissionTestingMap } from '../maps/air-emission-testing.map';
 import { AirEmissionTestingChecksService } from './air-emission-testing-checks.service';
+import { AirEmissionTestingModule } from '../air-emission-testing/air-emission-testing.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AirEmissionTestingWorkspaceRepository]),
     forwardRef(() => TestSummaryWorkspaceModule),
+    forwardRef(() => AirEmissionTestingModule),
     HttpModule,
   ],
   controllers: [AirEmissionTestingWorkspaceController],

--- a/src/air-emission-testing/air-emission-testing.service.spec.ts
+++ b/src/air-emission-testing/air-emission-testing.service.spec.ts
@@ -80,4 +80,14 @@ describe('AirEmissionTestingService', () => {
       expect(errored).toEqual(true);
     });
   });
+
+  describe('Export', () => {
+    it('Should Export Air Emission Testing', async () => {
+      jest
+        .spyOn(service, 'getAirEmissionTestingByTestSumIds')
+        .mockResolvedValue([airEmissionTestingRecord]);
+      const result = await service.export([testSumId]);
+      expect(result).toEqual([airEmissionTestingRecord]);
+    });
+  });
 });

--- a/src/air-emission-testing/air-emission-testing.service.ts
+++ b/src/air-emission-testing/air-emission-testing.service.ts
@@ -1,6 +1,7 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
+import { In } from 'typeorm';
 import { AirEmissionTestingDTO } from '../dto/air-emission-test.dto';
 import { AirEmissionTestingMap } from '../maps/air-emission-testing.map';
 import { AirEmissionTestingRepository } from './air-emission-testing.repository';
@@ -32,5 +33,18 @@ export class AirEmissionTestingService {
     }
 
     return this.map.one(result);
+  }
+
+  async getAirEmissionTestingByTestSumIds(
+    testSumIds: string[],
+  ): Promise<AirEmissionTestingDTO[]> {
+    const results = await this.repository.find({
+      where: { testSumId: In(testSumIds) },
+    });
+    return this.map.many(results);
+  }
+
+  async export(testSumIds: string[]): Promise<AirEmissionTestingDTO[]> {
+    return this.getAirEmissionTestingByTestSumIds(testSumIds);
   }
 }

--- a/src/test-qualification-workspace/test-qualification-workspace.module.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.module.ts
@@ -7,11 +7,13 @@ import { TestQualificationWorkspaceRepository } from './test-qualification-works
 import { TestQualificationMap } from '../maps/test-qualification.map';
 import { TestSummaryWorkspaceModule } from '../test-summary-workspace/test-summary.module';
 import { TestQualificationChecksService } from './test-qualification-checks.service';
+import { TestQualificationModule } from '../test-qualification/test-qualification.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([TestQualificationWorkspaceRepository]),
     forwardRef(() => TestSummaryWorkspaceModule),
+    forwardRef(() => TestQualificationModule),
     HttpModule,
   ],
   controllers: [TestQualificationWorkspaceController],

--- a/src/test-qualification-workspace/test-qualification-workspace.service.spec.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.service.spec.ts
@@ -3,6 +3,7 @@ import { TestSummaryWorkspaceService } from '../test-summary-workspace/test-summ
 import {
   TestQualificationBaseDTO,
   TestQualificationDTO,
+  TestQualificationImportDTO,
   TestQualificationRecordDTO,
 } from '../dto/test-qualification.dto';
 import { TestQualification } from '../entities/workspace/test-qualification.entity';
@@ -11,6 +12,8 @@ import { TestQualificationWorkspaceRepository } from './test-qualification-works
 import { TestQualificationWorkspaceService } from './test-qualification-workspace.service';
 import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
 import { HttpStatus } from '@nestjs/common/enums';
+import { Logger } from '@us-epa-camd/easey-common/logger';
+import { TestQualificationRepository } from '../test-qualification/test-qualification.repository';
 
 const testSumId = '';
 const testQualificationId = 'a1b2c3';
@@ -42,6 +45,10 @@ const mockMap = () => ({
   many: jest.fn().mockResolvedValue(testQualifications),
 });
 
+const mockHistoricalRepository = () => ({
+  findOne: jest.fn().mockResolvedValue(testQualificationRecord),
+});
+
 const mockTestSumService = () => ({
   resetToNeedsEvaluation: jest.fn(),
 });
@@ -54,6 +61,7 @@ describe('TestQualificationWorkspaceService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        Logger,
         TestQualificationWorkspaceService,
         {
           provide: TestSummaryWorkspaceService,
@@ -62,6 +70,10 @@ describe('TestQualificationWorkspaceService', () => {
         {
           provide: TestQualificationWorkspaceRepository,
           useFactory: mockRepository,
+        },
+        {
+          provide: TestQualificationRepository,
+          useFactory: mockHistoricalRepository,
         },
         {
           provide: TestQualificationMap,
@@ -181,6 +193,26 @@ describe('TestQualificationWorkspaceService', () => {
         errored = true;
       }
       expect(errored).toEqual(true);
+    });
+  });
+
+  describe('Export', () => {
+    it('Should Export Test Qualification', async () => {
+      jest
+        .spyOn(service, 'getTestQualificationByTestSumIds')
+        .mockResolvedValue([testQualificationRecord]);
+      const result = await service.export([testSumId]);
+      expect(result).toEqual([testQualificationRecord]);
+    });
+  });
+
+  describe('Import', () => {
+    it('Should Import Test Qualification', async () => {
+      jest
+        .spyOn(service, 'createTestQualification')
+        .mockResolvedValue(testQualificationRecord);
+
+      await service.import(testSumId, new TestQualificationImportDTO(), userId, true);
     });
   });
 });

--- a/src/test-qualification/test-qualification.service.spec.ts
+++ b/src/test-qualification/test-qualification.service.spec.ts
@@ -77,4 +77,14 @@ describe('TestQualificationService', () => {
       expect(repository.find).toHaveBeenCalled();
     });
   });
+
+  describe('Export', () => {
+    it('Should Export Test Qualification', async () => {
+      jest
+        .spyOn(service, 'getTestQualificationByTestSumIds')
+        .mockResolvedValue([testQualificationRecord]);
+      const result = await service.export([testSumId]);
+      expect(result).toEqual([testQualificationRecord]);
+    });
+  });
 });

--- a/src/test-qualification/test-qualification.service.ts
+++ b/src/test-qualification/test-qualification.service.ts
@@ -4,6 +4,7 @@ import { TestQualificationRepository } from './test-qualification.repository';
 import { TestQualificationMap } from '../maps/test-qualification.map';
 import { TestQualificationDTO } from '../dto/test-qualification.dto';
 import { LoggingException } from '@us-epa-camd/easey-common/exceptions';
+import { In } from 'typeorm';
 
 @Injectable()
 export class TestQualificationService {
@@ -34,5 +35,19 @@ export class TestQualificationService {
     }
 
     return this.map.one(result);
+  }
+
+  
+  async getTestQualificationByTestSumIds(
+    testSumIds: string[],
+  ): Promise<TestQualificationDTO[]> {
+    const results = await this.repository.find({
+      where: { testSumId: In(testSumIds) },
+    });
+    return this.map.many(results);
+  }
+
+  async export(testSumIds: string[]): Promise<TestQualificationDTO[]> {
+    return this.getTestQualificationByTestSumIds(testSumIds);
   }
 }

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -49,6 +49,10 @@ import { UnitDefaultTest } from '../entities/unit-default-test.entity';
 import { UnitDefaultTestWorkspaceService } from '../unit-default-test-workspace/unit-default-test-workspace.service';
 import { HgSummary } from '../entities/workspace/hg-summary.entity';
 import { HgSummaryWorkspaceService } from '../hg-summary-workspace/hg-summary-workspace.service';
+import { AirEmissionTesting } from '../entities/workspace/air-emission-test.entity';
+import { TestQualification } from '../entities/workspace/test-qualification.entity';
+import { TestQualificationWorkspaceService } from '../test-qualification-workspace/test-qualification-workspace.service';
+import { AirEmissionTestingWorkspaceService } from '../air-emission-testing-workspace/air-emission-testing-workspace.service';
 
 const locationId = '121';
 const facilityId = 1;
@@ -151,6 +155,16 @@ const mockTransmitterTransducerAccuracyWorkspaceService = () => ({
 
 const mockUnitDefaultTestWorkspaceService = () => ({
   export: jest.fn().mockResolvedValue([new UnitDefaultTest()]),
+  import: jest.fn().mockResolvedValue(null),
+});
+
+const mockAirEmissionTestingWorkspaceService = () => ({
+  export: jest.fn().mockResolvedValue([new AirEmissionTesting()]),
+  import: jest.fn().mockResolvedValue(null),
+});
+
+const mockTestQualificationWorkspaceService = () => ({
+  export: jest.fn().mockResolvedValue([new TestQualification()]),
   import: jest.fn().mockResolvedValue(null),
 });
 
@@ -272,6 +286,14 @@ describe('TestSummaryWorkspaceService', () => {
         {
           provide: UnitDefaultTestWorkspaceService,
           useFactory: mockUnitDefaultTestWorkspaceService,
+        },
+        {
+          provide: AirEmissionTestingWorkspaceService,
+          useFactory: mockAirEmissionTestingWorkspaceService,
+        },
+        {
+          provide: TestQualificationWorkspaceService,
+          useFactory: mockTestQualificationWorkspaceService,
         },
         {
           provide: HgSummaryWorkspaceService,

--- a/src/test-summary/test-summary.service.spec.ts
+++ b/src/test-summary/test-summary.service.spec.ts
@@ -37,6 +37,10 @@ import { TransmitterTransducerAccuracy } from '../entities/transmitter-transduce
 import { TransmitterTransducerAccuracyService } from '../transmitter-transducer-accuracy/transmitter-transducer-accuracy.service';
 import { HgSummary } from '../entities/hg-summary.entity';
 import { HgSummaryService } from '../hg-summary/hg-summary.service';
+import { AirEmissionTestingService } from '../air-emission-testing/air-emission-testing.service';
+import { TestQualificationService } from '../test-qualification/test-qualification.service';
+import { AirEmissionTesting } from '../entities/air-emission-test.entity';
+import { TestQualification } from '../entities/test-qualification.entity';
 
 const locationId = '121';
 const facilityId = 1;
@@ -112,6 +116,14 @@ const mockUnitDefaultTestService = () => ({
 
 const mockTransmitterTransducerAccuracyService = () => ({
   export: jest.fn().mockResolvedValue([new TransmitterTransducerAccuracy()]),
+});
+
+const mockAirEmissionTestingService = () => ({
+  export: jest.fn().mockResolvedValue([new AirEmissionTesting()]),
+});
+
+const mockTestQualificationService = () => ({
+  export: jest.fn().mockResolvedValue([new TestQualification()]),
 });
 
 const mockHgSummaryService = () => ({
@@ -190,6 +202,14 @@ describe('TestSummaryService', () => {
         {
           provide: TransmitterTransducerAccuracyService,
           useFactory: mockTransmitterTransducerAccuracyService,
+        },
+        {
+          provide: AirEmissionTestingService,
+          useFactory: mockAirEmissionTestingService,
+        },
+        {
+          provide: TestQualificationService,
+          useFactory: mockTestQualificationService,
         },
         {
           provide: HgSummaryService,

--- a/src/test-summary/test-summary.service.ts
+++ b/src/test-summary/test-summary.service.ts
@@ -22,6 +22,8 @@ import { FuelFlowmeterAccuracyService } from '../fuel-flowmeter-accuracy/fuel-fl
 import { UnitDefaultTestService } from '../unit-default-test/unit-default-test.service';
 import { TransmitterTransducerAccuracyService } from '../transmitter-transducer-accuracy/transmitter-transducer-accuracy.service';
 import { HgSummaryService } from '../hg-summary/hg-summary.service';
+import { AirEmissionTestingService } from '../air-emission-testing/air-emission-testing.service';
+import { TestQualificationService } from '../test-qualification/test-qualification.service';
 
 @Injectable()
 export class TestSummaryService {
@@ -60,6 +62,10 @@ export class TestSummaryService {
     private readonly transmitterTransducerAccuracyService: TransmitterTransducerAccuracyService,
     @Inject(forwardRef(() => HgSummaryService))
     private readonly hgSummaryService: HgSummaryService,
+    @Inject(forwardRef(() => AirEmissionTestingService))
+    private readonly airEmissionTestingService: AirEmissionTestingService,
+    @Inject(forwardRef(() => TestQualificationService))
+    private readonly testQualificationService: TestQualificationService,
   ) {}
 
   async getTestSummaryById(testSumId: string): Promise<TestSummaryDTO> {
@@ -150,7 +156,9 @@ export class TestSummaryService {
       onlineOfflineCalibrationData,
       unitDefaultTestData,
       transmitterTransducerAccuracyData,
-      hgSummaryData;
+      hgSummaryData,
+      testQualificationData,
+      airEmissionTestingData;
 
     let testSumIds;
 
@@ -211,6 +219,14 @@ export class TestSummaryService {
         testSumIds,
       );
 
+      testQualificationData = await this.testQualificationService.export(
+        testSumIds,
+      );
+
+      airEmissionTestingData = await this.airEmissionTestingService.export(
+        testSumIds,
+      );
+
       hgSummaryData = await this.hgSummaryService.export(testSumIds);
 
       testSummaries.forEach(s => {
@@ -250,6 +266,12 @@ export class TestSummaryService {
           i => i.testSumId === s.id,
         );
         s.transmitterTransducerData = transmitterTransducerAccuracyData.filter(
+          i => i.testSumId === s.id,
+        );
+        s.testQualificationData = testQualificationData.filter(
+          i => i.testSumId === s.id,
+        );
+        s.airEmissionTestingData = airEmissionTestingData.filter(
           i => i.testSumId === s.id,
         );
         s.hgSummaryData = hgSummaryData.filter(i => i.testSumId === s.id);


### PR DESCRIPTION
Issue:
The data elements for Test Qualification Data and Air Emission Testing Data are not available in the Import and Export endpoints. We need to add those

Add data elements to Export endpoints in both the Global and the workspace. Import is for Workspace only
Test Qualification Data is applicable to RATA only
AET data is applicable to RATA, Appendix-E and Unit Default
Steps to Recreate:

Login to ECMPS
Navigate to the Test Data module, select and check out a Configuration and locate a RATA record
Create Test Qualification and Air Emissions Testing Data and save
Now navigate to Export and for the same Configuration, locate the RATA record and export
You will notice that the AET and TQ data are missing in the export. The same behavior is observed when you Import data for RATA with Test Qualification Data and Air Emission Testing Data