### PR TITLE
Fixed bug where unitId wasn't accepted

### DIFF
--- a/src/dto/qa-certification-event.dto.ts
+++ b/src/dto/qa-certification-event.dto.ts
@@ -16,7 +16,7 @@ export class QACertificationEventBaseDTO {
   @IsString()
   stackPipeId: string;
   @ValidateIf((o) => !o.stackPipeId)
-  @RequireOne('unitId', {
+  @RequireOne('stackPipeId', {
     message:
       'A Unit or Stack Pipe identifier (NOT both) must be provided for each Test Summary.',
   })


### PR DESCRIPTION
Issue:
When a user wishes to create QA Cert Event Data, the system displays the following validation:
A Unit or Stack Pipe identifier (NOT both) must be provided for each Test Summary.

The Unit ID is available

Steps to Recreate:

Login to ECMPS and access the Cert Events, Ext and Exemptions Module
Select and check out a Configuration
Click on Add for QA Certification Event data
Once you enter all the information needed and click Save and Close, you will see the above validation displayed