### PR TITLE
Fixed issue where workspace MonitoringSystemIds aren't saved

### DIFF
--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -46,6 +46,7 @@ import { UnitDefaultTestWorkspaceService } from '../unit-default-test-workspace/
 import { HgSummaryWorkspaceService } from '../hg-summary-workspace/hg-summary-workspace.service';
 import { AirEmissionTestingWorkspaceService } from '../air-emission-testing-workspace/air-emission-testing-workspace.service';
 import { TestQualificationWorkspaceService } from '../test-qualification-workspace/test-qualification-workspace.service';
+import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 @Injectable()
 export class TestSummaryWorkspaceService {
@@ -72,6 +73,8 @@ export class TestSummaryWorkspaceService {
     private readonly componentRepository: ComponentWorkspaceRepository,
     @InjectRepository(MonitorSystemRepository)
     private readonly monSysRepository: MonitorSystemRepository,
+    @InjectRepository(MonitorSystemWorkspaceRepository)
+    private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
     @InjectRepository(ReportingPeriodRepository)
     private readonly reportingPeriodRepository: ReportingPeriodRepository,
     @Inject(forwardRef(() => FuelFlowToLoadBaselineWorkspaceService))
@@ -830,10 +833,16 @@ export class TestSummaryWorkspaceService {
     }
 
     if (payload.monitoringSystemID) {
-      const monitorSystem = await this.monSysRepository.findOne({
+      let monitorSystem = await this.monSysRepository.findOne({
         locationId: locationId,
         monitoringSystemID: payload.monitoringSystemID,
       });
+      if(!monitorSystem) {
+        monitorSystem = await this.monSysWorkspaceRepository.findOne({
+          locationId: locationId,
+          monitoringSystemID: payload.monitoringSystemID,
+        });
+      }
       monitoringSystemRecordId = monitorSystem ? monitorSystem.id : null;
     }
 


### PR DESCRIPTION
Issue:
Monitoring System IDs for Test Summary Data are populating in the workspace cannot be saved (back end issue)

Steps to Recreate:

Login to ECMPS, access Test Data module, select and checkout Dolet Hills Power Station (ORIS Code 51)
Add or Edit a Flow to Load Reference
Upon entering a Monitoring System Id that was created in the MP (1, 10, 12, 132, 90) and clicking save and close, the record is created but the Monitoring System Id is not saved even though other monitoring System Ids (333, 511, 512, etc...) are saved