### PR TITLE
Fixed issue where app-e-hi-oil wouldn't save with a workspace monitor…

### DIFF
--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.module.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.module.ts
@@ -10,11 +10,13 @@ import { AppEHeatInputFromOilWorkspaceRepository } from './app-e-heat-input-from
 import { AppEHeatInputFromOilMap } from '../maps/app-e-heat-input-from-oil.map';
 import { AppEHeatInputFromOilChecksService } from './app-e-heat-input-from-oil-checks.service';
 import { AppECorrelationTestRunWorkspaceModule } from '../app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.module';
+import { MonitorSystemWorkspaceModule } from '../monitor-system-workspace/monitor-system-workspace.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AppEHeatInputFromOilWorkspaceRepository]),
     forwardRef(() => TestSummaryWorkspaceModule),
+    forwardRef(() => MonitorSystemWorkspaceModule),
     forwardRef(() => AppECorrelationTestRunWorkspaceModule),
     forwardRef(() => AppEHeatInputFromOilModule),
     HttpModule,

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
@@ -14,6 +14,7 @@ import { MonitorSystemRepository } from '../monitor-system/monitor-system.reposi
 import { MonitorSystem } from '../entities/workspace/monitor-system.entity';
 import { AppEHeatInputFromGasRecordDTO } from '../dto/app-e-heat-input-from-gas.dto';
 import { AppEHeatInputFromOilRepository } from '../app-e-heat-input-from-oil/app-e-heat-input-from-oil.repository';
+import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 const locationId = '5';
 const aeHiOilId = 'a1b2c3';
@@ -45,6 +46,10 @@ const mockMonSysRepository = () => ({
   findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
 });
 
+const mockMonSysWorkspaceRepository = () => ({
+  findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
+});
+
 const mockMap = () => ({
   one: jest.fn().mockResolvedValue(mockAeHiFromOilDTO),
   many: jest.fn().mockResolvedValue([mockAeHiFromOilDTO]),
@@ -60,6 +65,7 @@ describe('AppEHeatInputOilWorkspaceService', () => {
   let service: AppEHeatInputFromOilWorkspaceService;
   let repository: AppEHeatInputFromOilWorkspaceRepository;
   let monSysRepository: MonitorSystemRepository;
+  let monSysWorkspaceRepository: MonitorSystemWorkspaceRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -77,6 +83,10 @@ describe('AppEHeatInputOilWorkspaceService', () => {
         {
           provide: MonitorSystemRepository,
           useFactory: mockMonSysRepository,
+        },
+        {
+          provide: MonitorSystemWorkspaceRepository,
+          useFactory: mockMonSysWorkspaceRepository,
         },
         {
           provide: AppEHeatInputFromOilMap,
@@ -97,6 +107,9 @@ describe('AppEHeatInputOilWorkspaceService', () => {
     );
     monSysRepository = module.get<MonitorSystemRepository>(
       MonitorSystemRepository,
+    );
+    monSysWorkspaceRepository = module.get<MonitorSystemWorkspaceRepository>(
+      MonitorSystemWorkspaceRepository,
     );
   });
 
@@ -147,6 +160,7 @@ describe('AppEHeatInputOilWorkspaceService', () => {
 
     it('Should throw error with invalid monSysID', async () => {
       jest.spyOn(monSysRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(monSysWorkspaceRepository, 'findOne').mockResolvedValue(null);
 
       let errored = false;
 

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
@@ -17,6 +17,7 @@ import {
 import { AppEHeatInputFromOil } from '../entities/app-e-heat-input-from-oil.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
+import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 @Injectable()
 export class AppEHeatInputFromOilWorkspaceService {
@@ -31,6 +32,8 @@ export class AppEHeatInputFromOilWorkspaceService {
     private readonly testSummaryService: TestSummaryWorkspaceService,
     @InjectRepository(MonitorSystemRepository)
     private readonly monSysRepository: MonitorSystemRepository,
+    @InjectRepository(MonitorSystemWorkspaceRepository)
+    private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
   ) {}
 
   async getAppEHeatInputFromOilRecords(
@@ -69,10 +72,16 @@ export class AppEHeatInputFromOilWorkspaceService {
   ): Promise<AppEHeatInputFromOilRecordDTO> {
     const timestamp = currentDateTime().toLocaleDateString();
 
-    const system = await this.monSysRepository.findOne({
+    let system = await this.monSysRepository.findOne({
       locationId: locationId,
       monitoringSystemID: payload.monitoringSystemID,
     });
+    if(!system) {
+      system = await this.monSysWorkspaceRepository.findOne({
+        locationId: locationId,
+        monitoringSystemID: payload.monitoringSystemID,
+      });
+    }
 
     if (!system) {
       throw new LoggingException(


### PR DESCRIPTION
Issue:
Users are able to pick the Mon Sys ID's for Appendix E Correlation Heat Input from Oil, but unable to save the selections

Steps to Recreate:

Login to ECMPS, access the Test Data Module
Navigate to and check out Dolet Hills Power Station (ORIS Code 51)
Add or Edit an Appendix E Correlation Heat Input from Oil
Upon entering a Monitoring System Id that was created in the MP (1, 10, 12, 132, 90) and clicking save and close, the record is created but the Monitoring System Id is not saved even though other monitoring System Ids (333, 511, 512, etc...) are saved