### PR TITLE
Fixed issue where app-e-hi-gas wouldn't save with a workspace monitor…

### DIFF
--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.module.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.module.ts
@@ -10,11 +10,13 @@ import { AppECorrelationTestSummaryWorkspaceModule } from '../app-e-correlation-
 import { AppEHeatInputFromGasModule } from '../app-e-heat-input-from-gas/app-e-heat-input-from-gas.module';
 import { AppEHeatInputFromGasChecksService } from './app-e-heat-input-from-gas-checks.service';
 import { AppECorrelationTestRunWorkspaceModule } from '../app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.module';
+import { MonitorSystemWorkspaceModule } from '../monitor-system-workspace/monitor-system-workspace.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AppEHeatInputFromGasWorkspaceRepository]),
     forwardRef(() => TestSummaryWorkspaceModule),
+    forwardRef(() => MonitorSystemWorkspaceModule),
     forwardRef(() => AppECorrelationTestSummaryWorkspaceModule),
     forwardRef(() => AppECorrelationTestRunWorkspaceModule),
     forwardRef(() => AppEHeatInputFromGasModule),

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorSystem } from '../entities/workspace/monitor-system.entity';
-import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
 import {
   AppEHeatInputFromGasDTO,
   AppEHeatInputFromGasImportDTO,
@@ -51,10 +50,6 @@ const mockRepository = () => ({
   findOne: jest.fn().mockResolvedValue(mockAeHiFromGas),
 });
 
-const mockMonSysRepository = () => ({
-  findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
-});
-
 const mockMonSysWorkspaceRepository = () => ({
   findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
 });
@@ -67,7 +62,6 @@ const mockMap = () => ({
 describe('AppEHeatInputFromGasWorkspaceService', () => {
   let service: AppEHeatInputFromGasWorkspaceService;
   let repository: AppEHeatInputFromGasWorkspaceRepository;
-  let monSysRepository: MonitorSystemRepository;
   let monSysWorkspaceRepository: MonitorSystemWorkspaceRepository;
 
   beforeEach(async () => {
@@ -92,10 +86,6 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
           useFactory: mockRepository,
         },
         {
-          provide: MonitorSystemRepository,
-          useFactory: mockMonSysRepository,
-        },
-        {
           provide: MonitorSystemWorkspaceRepository,
           useFactory: mockMonSysWorkspaceRepository,
         },
@@ -111,9 +101,6 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
     );
     repository = module.get<AppEHeatInputFromGasWorkspaceRepository>(
       AppEHeatInputFromGasWorkspaceRepository,
-    );
-    monSysRepository = module.get<MonitorSystemRepository>(
-      MonitorSystemRepository,
     );
     monSysWorkspaceRepository = module.get<MonitorSystemWorkspaceRepository>(
       MonitorSystemWorkspaceRepository,
@@ -189,7 +176,6 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
     });
 
     it('Should throw error with invalid monSysID', async () => {
-      jest.spyOn(monSysRepository, 'findOne').mockResolvedValue(null);
       jest.spyOn(monSysWorkspaceRepository, 'findOne').mockResolvedValue(null);
 
       let errored = false;

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.spec.ts
@@ -13,6 +13,7 @@ import { AppEHeatInputFromGasWorkspaceRepository } from './app-e-heat-input-from
 import { AppEHeatInputFromGasWorkspaceService } from './app-e-heat-input-from-gas-workspace.service';
 import { AppEHeatInputFromGas } from '../entities/workspace/app-e-heat-input-from-gas.entity';
 import { AppEHeatInputFromGasRepository } from '../app-e-heat-input-from-gas/app-e-heat-input-from-gas.repository';
+import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 const locationId = 'LOCATION-ID';
 const testSumId = 'TEST-SUM-ID';
@@ -32,6 +33,7 @@ const mockHistoricalRepo = () => ({
 const appECorrTestRunId = 'd4e6f7';
 const mockAeHiFromGas = new AppEHeatInputFromGas();
 const mockAeHiFromGasDTO = new AppEHeatInputFromGasDTO();
+const payload = new AppEHeatInputFromGasDTO();
 
 const mockTestSumService = () => ({
   resetToNeedsEvaluation: jest.fn(),
@@ -41,12 +43,19 @@ const mockRepository = () => ({
   getAppEHeatInputFromGasesByTestRunIds: jest
     .fn()
     .mockResolvedValue([mockAeHiFromGas]),
+  getAppEHeatInputFromGasById: jest
+    .fn()
+    .mockResolvedValue(mockAeHiFromGas),
   create: jest.fn().mockResolvedValue(mockAeHiFromGas),
   save: jest.fn().mockResolvedValue(mockAeHiFromGas),
   findOne: jest.fn().mockResolvedValue(mockAeHiFromGas),
 });
 
 const mockMonSysRepository = () => ({
+  findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
+});
+
+const mockMonSysWorkspaceRepository = () => ({
   findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
 });
 
@@ -58,6 +67,8 @@ const mockMap = () => ({
 describe('AppEHeatInputFromGasWorkspaceService', () => {
   let service: AppEHeatInputFromGasWorkspaceService;
   let repository: AppEHeatInputFromGasWorkspaceRepository;
+  let monSysRepository: MonitorSystemRepository;
+  let monSysWorkspaceRepository: MonitorSystemWorkspaceRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -85,6 +96,10 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
           useFactory: mockMonSysRepository,
         },
         {
+          provide: MonitorSystemWorkspaceRepository,
+          useFactory: mockMonSysWorkspaceRepository,
+        },
+        {
           provide: AppEHeatInputFromGasMap,
           useFactory: mockMap,
         },
@@ -93,6 +108,15 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
 
     service = module.get<AppEHeatInputFromGasWorkspaceService>(
       AppEHeatInputFromGasWorkspaceService,
+    );
+    repository = module.get<AppEHeatInputFromGasWorkspaceRepository>(
+      AppEHeatInputFromGasWorkspaceRepository,
+    );
+    monSysRepository = module.get<MonitorSystemRepository>(
+      MonitorSystemRepository,
+    );
+    monSysWorkspaceRepository = module.get<MonitorSystemWorkspaceRepository>(
+      MonitorSystemWorkspaceRepository,
     );
   });
 
@@ -148,6 +172,41 @@ describe('AppEHeatInputFromGasWorkspaceService', () => {
 
       const result = await service.export([appECorrTestRunId]);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('createAppEHeatInputFromGasRecord', () => {
+    it('calls the repository.create() and insert an Appendix E Heat Input from Gas record', async () => {
+      const result = await service.createAppEHeatInputFromGas(
+        locationId,
+        testSumId,
+        appECorrTestRunId,
+        payload,
+        userId,
+      );
+      expect(result).toEqual(mockAeHiFromGasDTO);
+      expect(repository.create).toHaveBeenCalled();
+    });
+
+    it('Should throw error with invalid monSysID', async () => {
+      jest.spyOn(monSysRepository, 'findOne').mockResolvedValue(null);
+      jest.spyOn(monSysWorkspaceRepository, 'findOne').mockResolvedValue(null);
+
+      let errored = false;
+
+      try {
+        await service.createAppEHeatInputFromGas(
+          locationId,
+          testSumId,
+          appECorrTestRunId,
+          payload,
+          userId,
+        );
+      } catch (err) {
+        errored = true;
+      }
+
+      expect(errored).toBe(true);
     });
   });
 });

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
@@ -16,7 +16,6 @@ import {
 } from '../dto/app-e-heat-input-from-gas.dto';
 import { AppEHeatInputFromGas } from '../entities/app-e-heat-input-from-gas.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
-import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
 import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 @Injectable()
@@ -30,8 +29,6 @@ export class AppEHeatInputFromGasWorkspaceService {
     private readonly repository: AppEHeatInputFromGasWorkspaceRepository,
     @InjectRepository(AppEHeatInputFromGasRepository)
     private readonly historicalRepo: AppEHeatInputFromGasRepository,
-    @InjectRepository(MonitorSystemRepository)
-    private readonly monSysRepository: MonitorSystemRepository,
     @InjectRepository(MonitorSystemWorkspaceRepository)
     private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
   ) {}
@@ -72,16 +69,10 @@ export class AppEHeatInputFromGasWorkspaceService {
   ): Promise<AppEHeatInputFromGasRecordDTO> {
     const timestamp = currentDateTime();
 
-    let system = await this.monSysRepository.findOne({
+    const system = await this.monSysWorkspaceRepository.findOne({
       locationId: locationId,
       monitoringSystemID: payload.monitoringSystemID,
     });
-    if(!system) {
-      system = await this.monSysWorkspaceRepository.findOne({
-        locationId: locationId,
-        monitoringSystemID: payload.monitoringSystemID,
-      });
-    }
 
     if (!system) {
       throw new LoggingException(

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.service.ts
@@ -17,6 +17,7 @@ import {
 import { AppEHeatInputFromGas } from '../entities/app-e-heat-input-from-gas.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
+import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 @Injectable()
 export class AppEHeatInputFromGasWorkspaceService {
@@ -31,6 +32,8 @@ export class AppEHeatInputFromGasWorkspaceService {
     private readonly historicalRepo: AppEHeatInputFromGasRepository,
     @InjectRepository(MonitorSystemRepository)
     private readonly monSysRepository: MonitorSystemRepository,
+    @InjectRepository(MonitorSystemWorkspaceRepository)
+    private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
   ) {}
 
   async getAppEHeatInputFromGases(
@@ -69,10 +72,16 @@ export class AppEHeatInputFromGasWorkspaceService {
   ): Promise<AppEHeatInputFromGasRecordDTO> {
     const timestamp = currentDateTime();
 
-    const system = await this.monSysRepository.findOne({
+    let system = await this.monSysRepository.findOne({
       locationId: locationId,
       monitoringSystemID: payload.monitoringSystemID,
     });
+    if(!system) {
+      system = await this.monSysWorkspaceRepository.findOne({
+        locationId: locationId,
+        monitoringSystemID: payload.monitoringSystemID,
+      });
+    }
 
     if (!system) {
       throw new LoggingException(

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.spec.ts
@@ -42,10 +42,6 @@ const mockRepository = () => ({
   getAppEHeatInputFromOilById: jest.fn().mockResolvedValue(mockAeHiFromOil),
 });
 
-const mockMonSysRepository = () => ({
-  findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
-});
-
 const mockMonSysWorkspaceRepository = () => ({
   findOne: jest.fn().mockResolvedValue(new MonitorSystem()),
 });
@@ -64,7 +60,6 @@ const mockHistoricalRepo = () => ({
 describe('AppEHeatInputOilWorkspaceService', () => {
   let service: AppEHeatInputFromOilWorkspaceService;
   let repository: AppEHeatInputFromOilWorkspaceRepository;
-  let monSysRepository: MonitorSystemRepository;
   let monSysWorkspaceRepository: MonitorSystemWorkspaceRepository;
 
   beforeEach(async () => {
@@ -79,10 +74,6 @@ describe('AppEHeatInputOilWorkspaceService', () => {
         {
           provide: AppEHeatInputFromOilWorkspaceRepository,
           useFactory: mockRepository,
-        },
-        {
-          provide: MonitorSystemRepository,
-          useFactory: mockMonSysRepository,
         },
         {
           provide: MonitorSystemWorkspaceRepository,
@@ -104,9 +95,6 @@ describe('AppEHeatInputOilWorkspaceService', () => {
     );
     repository = module.get<AppEHeatInputFromOilWorkspaceRepository>(
       AppEHeatInputFromOilWorkspaceRepository,
-    );
-    monSysRepository = module.get<MonitorSystemRepository>(
-      MonitorSystemRepository,
     );
     monSysWorkspaceRepository = module.get<MonitorSystemWorkspaceRepository>(
       MonitorSystemWorkspaceRepository,
@@ -159,7 +147,6 @@ describe('AppEHeatInputOilWorkspaceService', () => {
     });
 
     it('Should throw error with invalid monSysID', async () => {
-      jest.spyOn(monSysRepository, 'findOne').mockResolvedValue(null);
       jest.spyOn(monSysWorkspaceRepository, 'findOne').mockResolvedValue(null);
 
       let errored = false;

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.service.ts
@@ -16,7 +16,6 @@ import {
 } from '../dto/app-e-heat-input-from-oil.dto';
 import { AppEHeatInputFromOil } from '../entities/app-e-heat-input-from-oil.entity';
 import { Logger } from '@us-epa-camd/easey-common/logger';
-import { MonitorSystemRepository } from '../monitor-system/monitor-system.repository';
 import { MonitorSystemWorkspaceRepository } from '../monitor-system-workspace/monitor-system-workspace.repository';
 
 @Injectable()
@@ -30,8 +29,6 @@ export class AppEHeatInputFromOilWorkspaceService {
     private readonly map: AppEHeatInputFromOilMap,
     @Inject(forwardRef(() => TestSummaryWorkspaceService))
     private readonly testSummaryService: TestSummaryWorkspaceService,
-    @InjectRepository(MonitorSystemRepository)
-    private readonly monSysRepository: MonitorSystemRepository,
     @InjectRepository(MonitorSystemWorkspaceRepository)
     private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
   ) {}
@@ -72,16 +69,10 @@ export class AppEHeatInputFromOilWorkspaceService {
   ): Promise<AppEHeatInputFromOilRecordDTO> {
     const timestamp = currentDateTime().toLocaleDateString();
 
-    let system = await this.monSysRepository.findOne({
+    const system = await this.monSysWorkspaceRepository.findOne({
       locationId: locationId,
       monitoringSystemID: payload.monitoringSystemID,
     });
-    if(!system) {
-      system = await this.monSysWorkspaceRepository.findOne({
-        locationId: locationId,
-        monitoringSystemID: payload.monitoringSystemID,
-      });
-    }
 
     if (!system) {
       throw new LoggingException(

--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -314,7 +314,6 @@ describe('TestSummaryWorkspaceService', () => {
     service = module.get(TestSummaryWorkspaceService);
     repository = module.get(TestSummaryWorkspaceRepository);
     locationRepository = module.get(MonitorLocationRepository);
-    monitorSystemRepository = module.get(MonitorSystemRepository);
     monitorSystemWorkspaceRepository = module.get(MonitorSystemWorkspaceRepository);
   });
 
@@ -497,18 +496,13 @@ describe('TestSummaryWorkspaceService', () => {
       const monSysData = new MonitorSystem();
       monSysData.id = '1';
 
-      const monSysFindOne = jest
-        .spyOn(monitorSystemRepository, 'findOne')
-        .mockResolvedValue(null);
-
       const monSysWksFindOne = jest
-        .spyOn(monitorSystemRepository, 'findOne')
+        .spyOn(monitorSystemWorkspaceRepository, 'findOne')
         .mockResolvedValue(monSysData);
 
       const result = await service.lookupValues(locationId, payload);
 
       expect(result).toEqual([1, '1', '1']);
-      expect(monSysFindOne).toHaveBeenCalled();
       expect(monSysWksFindOne).toHaveBeenCalled();
     });
   });

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -71,8 +71,6 @@ export class TestSummaryWorkspaceService {
     private readonly monitorLocationRepository: MonitorLocationRepository,
     @InjectRepository(ComponentWorkspaceRepository)
     private readonly componentRepository: ComponentWorkspaceRepository,
-    @InjectRepository(MonitorSystemRepository)
-    private readonly monSysRepository: MonitorSystemRepository,
     @InjectRepository(MonitorSystemWorkspaceRepository)
     private readonly monSysWorkspaceRepository: MonitorSystemWorkspaceRepository,
     @InjectRepository(ReportingPeriodRepository)
@@ -833,16 +831,11 @@ export class TestSummaryWorkspaceService {
     }
 
     if (payload.monitoringSystemID) {
-      let monitorSystem = await this.monSysRepository.findOne({
+      const monitorSystem = await this.monSysWorkspaceRepository.findOne({
         locationId: locationId,
         monitoringSystemID: payload.monitoringSystemID,
       });
-      if(!monitorSystem) {
-        monitorSystem = await this.monSysWorkspaceRepository.findOne({
-          locationId: locationId,
-          monitoringSystemID: payload.monitoringSystemID,
-        });
-      }
+      
       monitoringSystemRecordId = monitorSystem ? monitorSystem.id : null;
     }
 


### PR DESCRIPTION
Issue:
Users are able to pick the Mon Sys ID's for Appendix E Correlation Heat Input from Gas, but unable to save the selections

Steps to Recreate:

Login to ECMPS, access the Test Data Module
Navigate to and check out Dolet Hills Power Station (ORIS Code 51)
Add or Edit an Appendix E Correlation Heat Input from Gas
Upon entering a Monitoring System Id that was created in the MP (1, 10, 12, 132, 90) and clicking save and close, the record is created but the Monitoring System Id is not saved even though other monitoring System Ids (333, 511, 512, etc...) are saved