### PR TITLE
Bug/5131 set eval flag

### DIFF
--- a/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.service.ts
+++ b/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.service.ts
@@ -182,6 +182,12 @@ export class AppECorrelationTestSummaryWorkspaceService {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
+
+    await this.testSummaryService.resetToNeedsEvaluation(
+      testSumId,
+      userId,
+      isImport,
+    );
   }
 
   async getAppECorrelationsByTestSumIds(

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
@@ -193,6 +193,9 @@ export class QACertificationEventWorkspaceService {
     entity.completionTestHour = payload.completionTestHour;
     entity.userId = userId;
     entity.updateDate = timestamp;
+    entity.needsEvalFlag = 'Y';
+    entity.updatedStatusFlag = 'Y';
+    entity.evalStatusCode = 'EVAL';
 
     await this.repository.save(entity);
 


### PR DESCRIPTION
Fix the deletion of a child App-e-summary record so that it resets parent evaluation status and fix updating a QA Cert test so that it also resets evaluation status