### PR TITLE
🐛Bug/5130: Export-QA-Cert-Event-&-TEE-Data-based-on-reporting-period

### DIFF
--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace-checks.service.spec.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace-checks.service.spec.ts
@@ -119,7 +119,13 @@ describe('Cycle Time Injection Check Service Test', () => {
       payload.gasLevelCode = 'MID';
       jest.spyOn(repository, 'findDuplicate').mockResolvedValue(duplicate);
 
-      let result = await service.cycle20Check(null, payload, [payload], testSummary, false);
+      let result = await service.cycle20Check(
+        null,
+        payload,
+        [payload],
+        testSummary,
+        false,
+      );
       expect(result).toEqual(MOCK_ERROR_MSG);
     });
   });

--- a/src/dto/cycle-time-summary.dto.ts
+++ b/src/dto/cycle-time-summary.dto.ts
@@ -1,35 +1,39 @@
 import { Type } from 'class-transformer';
-import {ValidateNested, IsNumber, IsOptional, IsInt, ValidationArguments} from 'class-validator';
+import {
+  ValidateNested,
+  IsNumber,
+  IsOptional,
+  IsInt,
+  ValidationArguments,
+} from 'class-validator';
 import {
   CycleTimeInjectionDTO,
   CycleTimeInjectionImportDTO,
 } from './cycle-time-injection.dto';
-import {IsInRange} from "@us-epa-camd/easey-common/pipes";
-import {CheckCatalogService} from "@us-epa-camd/easey-common/check-catalog";
+import { IsInRange } from '@us-epa-camd/easey-common/pipes';
+import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 
 const KEY = 'Cycle Time Summary';
 const TOTAL_TIME_VALID_MSG = (args: ValidationArguments) => {
   return CheckCatalogService.formatMessage(
-      'The value [value] in the field [fieldname] for [key] is invalid. ' +
+    'The value [value] in the field [fieldname] for [key] is invalid. ' +
       'This value must be an integer from 0 to 99',
-      {
-        fieldname: args.property,
-        value: args.value,
-        key: KEY,
-      },
+    {
+      fieldname: args.property,
+      value: args.value,
+      key: KEY,
+    },
   );
-}
+};
 
 export class CycleTimeSummaryBaseDTO {
-
   @IsOptional()
   @IsInt({
     message: TOTAL_TIME_VALID_MSG,
   })
   @IsInRange(0, 99, {
-        message: TOTAL_TIME_VALID_MSG,
-      }
-  )
+    message: TOTAL_TIME_VALID_MSG,
+  })
   totalTime?: number;
 }
 

--- a/src/qa-certification-event-workspace/qa-certification-event-checks.service.spec.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-checks.service.spec.ts
@@ -48,7 +48,13 @@ describe('QACertificationEventChecksService', () => {
 
   describe('QA Certification Event Checks', () => {
     it('Should pass all checks', async () => {
-      const result = await service.runChecks(locationId, payload, null, false, false);
+      const result = await service.runChecks(
+        locationId,
+        payload,
+        null,
+        false,
+        false,
+      );
       expect(result).toEqual([]);
     });
 

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.repository.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.repository.ts
@@ -1,4 +1,5 @@
 import {
+  addBeginAndEndDateWhere,
   addJoins,
   addQACertEventIdWhere,
 } from '../utilities/qa-cert-events.querybuilder';
@@ -37,6 +38,8 @@ export class QACertificationEventWorkspaceRepository extends Repository<
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEvent[]> {
     let unitsWhere =
       unitIds && unitIds.length > 0
@@ -67,6 +70,11 @@ export class QACertificationEventWorkspaceRepository extends Repository<
     query = addQACertEventIdWhere(query, qaCertEventIds) as SelectQueryBuilder<
       QACertificationEvent
     >;
+    query = addBeginAndEndDateWhere(
+      query,
+      beginDate,
+      endDate,
+    ) as SelectQueryBuilder<QACertificationEvent>;
 
     return query.getMany();
   }

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
@@ -154,12 +154,16 @@ export class QACertificationEventWorkspaceService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertificationEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEventDTO[]> {
     const results = await this.repository.getQaCertEventsByUnitStack(
       facilityId,
       unitIds,
       stackPipeIds,
       qaCertificationEventIds,
+      beginDate,
+      endDate,
     );
 
     return this.map.many(results);
@@ -207,12 +211,16 @@ export class QACertificationEventWorkspaceService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertificationEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEventDTO[]> {
     const qaCertEvents = await this.getQACertEvents(
       facilityId,
       unitIds,
       stackPipeIds,
       qaCertificationEventIds,
+      beginDate,
+      endDate,
     );
 
     return qaCertEvents;

--- a/src/qa-certification-event/qa-certification-event.repository.ts
+++ b/src/qa-certification-event/qa-certification-event.repository.ts
@@ -1,4 +1,5 @@
 import {
+  addBeginAndEndDateWhere,
   addJoins,
   addQACertEventIdWhere,
 } from '../utilities/qa-cert-events.querybuilder';
@@ -37,6 +38,8 @@ export class QACertificationEventRepository extends Repository<
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertificationEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEvent[]> {
     let unitsWhere =
       unitIds && unitIds.length > 0
@@ -67,6 +70,12 @@ export class QACertificationEventRepository extends Repository<
     query = addQACertEventIdWhere(
       query,
       qaCertificationEventIds,
+    ) as SelectQueryBuilder<QACertificationEvent>;
+
+    query = addBeginAndEndDateWhere(
+      query,
+      beginDate,
+      endDate,
     ) as SelectQueryBuilder<QACertificationEvent>;
 
     return query.getMany();

--- a/src/qa-certification-event/qa-certification-event.service.ts
+++ b/src/qa-certification-event/qa-certification-event.service.ts
@@ -45,12 +45,16 @@ export class QaCertificationEventService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertificationEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEventDTO[]> {
     const results = await this.repository.getQaCertEventsByUnitStack(
       facilityId,
       unitIds,
       stackPipeIds,
       qaCertificationEventIds,
+      beginDate,
+      endDate,
     );
 
     return this.map.many(results);
@@ -61,12 +65,16 @@ export class QaCertificationEventService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaCertificationEventIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<QACertificationEventDTO[]> {
     const testSummaries = await this.getQACertEvents(
       facilityId,
       unitIds,
       stackPipeIds,
       qaCertificationEventIds,
+      beginDate,
+      endDate,
     );
 
     return testSummaries;

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -46,6 +46,8 @@ export class QACertificationWorkspaceService {
         params.unitIds,
         params.stackPipeIds,
         params.qaCertificationEventIds,
+        params.beginDate,
+        params.endDate,
       ),
     );
     const EXT_EXEMPTIONS = EVENTS + 1;
@@ -55,6 +57,8 @@ export class QACertificationWorkspaceService {
         params.unitIds,
         params.stackPipeIds,
         params.qaTestExtensionExemptionIds,
+        params.beginDate,
+        params.endDate,
       ),
     );
 

--- a/src/qa-certification/qa-certification.service.ts
+++ b/src/qa-certification/qa-certification.service.ts
@@ -40,6 +40,8 @@ export class QACertificationService {
         params.unitIds,
         params.stackPipeIds,
         params.qaCertificationEventIds,
+        params.beginDate,
+        params.endDate,
       ),
     );
 
@@ -50,6 +52,8 @@ export class QACertificationService {
         params.unitIds,
         params.stackPipeIds,
         params.qaTestExtensionExemptionIds,
+        params.beginDate,
+        params.endDate,
       ),
     );
 

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-checks.service.spec.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-checks.service.spec.ts
@@ -53,7 +53,13 @@ describe('TestExtensionExemptionsChecksService', () => {
 
   describe('Test Extension Exemptions Checks', () => {
     it('Should pass all checks', async () => {
-      const result = await service.runChecks(locationId, payload, null, false, false);
+      const result = await service.runChecks(
+        locationId,
+        payload,
+        null,
+        false,
+        false,
+      );
       expect(result).toEqual([]);
     });
 

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.repository.ts
@@ -1,4 +1,5 @@
 import {
+  addBeginAndEndDateWhere,
   addJoins,
   addTestExtExemIdWhere,
 } from '../utilities/test-extension-exemption.querybuilder';
@@ -49,6 +50,8 @@ export class TestExtensionExemptionsWorkspaceRepository extends Repository<
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemption[]> {
     let unitsWhere =
       unitIds && unitIds.length > 0
@@ -79,6 +82,12 @@ export class TestExtensionExemptionsWorkspaceRepository extends Repository<
     query = addTestExtExemIdWhere(
       query,
       qaTestExtensionExemptionIds,
+    ) as SelectQueryBuilder<TestExtensionExemption>;
+
+    query = addBeginAndEndDateWhere(
+      query,
+      beginDate,
+      endDate,
     ) as SelectQueryBuilder<TestExtensionExemption>;
 
     return query.getMany();

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
@@ -68,12 +68,16 @@ export class TestExtensionExemptionsWorkspaceService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemptionDTO[]> {
     const results = await this.repository.getTestExtensionsByUnitStack(
       facilityId,
       unitIds,
       stackPipeIds,
       qaTestExtensionExemptionIds,
+      beginDate,
+      endDate,
     );
     return this.map.many(results);
   }
@@ -83,12 +87,16 @@ export class TestExtensionExemptionsWorkspaceService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemptionDTO[]> {
     const results = await this.getTestExtensions(
       facilityId,
       unitIds,
       stackPipeIds,
       qaTestExtensionExemptionIds,
+      beginDate,
+      endDate,
     );
     return results;
   }

--- a/src/test-extension-exemptions/test-extension-exemptions.repository.ts
+++ b/src/test-extension-exemptions/test-extension-exemptions.repository.ts
@@ -1,4 +1,5 @@
 import {
+  addBeginAndEndDateWhere,
   addJoins,
   addTestExtExemIdWhere,
 } from '../utilities/test-extension-exemption.querybuilder';
@@ -40,6 +41,8 @@ export class TestExtensionExemptionsRepository extends Repository<
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemption[]> {
     let unitsWhere =
       unitIds && unitIds.length > 0
@@ -71,6 +74,12 @@ export class TestExtensionExemptionsRepository extends Repository<
       query,
       qaTestExtensionExemptionIds,
     ) as SelectQueryBuilder<TestExtensionExemption>;
+    query = addBeginAndEndDateWhere(
+      query,
+      beginDate,
+      endDate,
+    ) as SelectQueryBuilder<TestExtensionExemption>;
+
     return query.getMany();
   }
 }

--- a/src/test-extension-exemptions/test-extension-exemptions.service.ts
+++ b/src/test-extension-exemptions/test-extension-exemptions.service.ts
@@ -46,12 +46,16 @@ export class TestExtensionExemptionsService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemptionDTO[]> {
     const results = await this.repository.getTestExtensionsByUnitStack(
       facilityId,
       unitIds,
       stackPipeIds,
       qaTestExtensionExemptionIds,
+      beginDate,
+      endDate,
     );
     return this.map.many(results);
   }
@@ -61,12 +65,16 @@ export class TestExtensionExemptionsService {
     unitIds?: string[],
     stackPipeIds?: string[],
     qaTestExtensionExemptionIds?: string[],
+    beginDate?: Date,
+    endDate?: Date,
   ): Promise<TestExtensionExemptionDTO[]> {
     const results = await this.getTestExtensions(
       facilityId,
       unitIds,
       stackPipeIds,
       qaTestExtensionExemptionIds,
+      beginDate,
+      endDate,
     );
     return results;
   }

--- a/src/utilities/qa-cert-events.querybuilder.ts
+++ b/src/utilities/qa-cert-events.querybuilder.ts
@@ -1,6 +1,6 @@
 import { QACertificationEvent } from '../entities/qa-certification-event.entity';
 import { QACertificationEvent as WorkspaceQACertificationEvent } from '../entities/workspace/qa-certification-event.entity';
-import { SelectQueryBuilder } from 'typeorm';
+import { Brackets, SelectQueryBuilder } from 'typeorm';
 
 export const addJoins = (
   query: SelectQueryBuilder<
@@ -26,5 +26,33 @@ export const addQACertEventIdWhere = (
       qaCertificationEventIds,
     });
   }
+  return query;
+};
+
+export const addBeginAndEndDateWhere = (
+  query: SelectQueryBuilder<
+    QACertificationEvent | WorkspaceQACertificationEvent
+  >,
+  beginDate: Date,
+  endDate: Date,
+): SelectQueryBuilder<QACertificationEvent | WorkspaceQACertificationEvent> => {
+  if (beginDate && endDate) {
+    query.andWhere(
+      new Brackets(qb1 => {
+        qb1.where(
+          new Brackets(qb2 => {
+            qb2.andWhere(
+              'qce.qaCertEventDate BETWEEN :beginDate AND :endDate',
+              {
+                beginDate,
+                endDate,
+              },
+            );
+          }),
+        );
+      }),
+    );
+  }
+
   return query;
 };

--- a/src/utilities/test-extension-exemption.querybuilder.ts
+++ b/src/utilities/test-extension-exemption.querybuilder.ts
@@ -1,4 +1,4 @@
-import { SelectQueryBuilder } from 'typeorm';
+import { Brackets, SelectQueryBuilder } from 'typeorm';
 import { TestExtensionExemption } from '../entities/test-extension-exemption.entity';
 import { TestExtensionExemption as WorkspaceTestExtensionExemption } from '../entities/workspace/test-extension-exemption.entity';
 
@@ -31,5 +31,31 @@ export const addTestExtExemIdWhere = (
       qaTestExtensionExemptionIds,
     });
   }
+  return query;
+};
+
+export const addBeginAndEndDateWhere = (
+  query: SelectQueryBuilder<
+    TestExtensionExemption | WorkspaceTestExtensionExemption
+  >,
+  beginDate: Date,
+  endDate: Date,
+): SelectQueryBuilder<
+  TestExtensionExemption | WorkspaceTestExtensionExemption
+> => {
+  if (beginDate && endDate) {
+    query.andWhere(
+      new Brackets(qb1 => {
+        qb1.where(
+          new Brackets(qb2 => {
+            qb2
+              .where('rp.beginDate = :beginDate', { beginDate })
+              .andWhere('rp.endDate = :endDate', { endDate });
+          }),
+        );
+      }),
+    );
+  }
+
   return query;
 };


### PR DESCRIPTION
## [🐛Bug/5130: Export-QA-Cert-Event-&-TEE-Data-based-on-reporting-period](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/gh/us-epa-camd/easey-ui/5130)