### PR TITLE
Fixed rata 17 and 18 checks

### DIFF
--- a/src/dto/rata-summary.dto.ts
+++ b/src/dto/rata-summary.dto.ts
@@ -7,6 +7,7 @@ import {
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  IsPositive,
   ValidateIf,
   ValidateNested,
   ValidationArguments,
@@ -102,7 +103,6 @@ export class RataSummaryBaseDTO {
   @ApiProperty({
     description: 'meanRATAReferenceValue. ADD TO PROPERTY METADATA',
   })
-  @IsOptional()
   @IsNotEmpty({
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatResultMessage('RATA-18-A', {
@@ -111,9 +111,7 @@ export class RataSummaryBaseDTO {
       });
     },
   })
-  @IsInRange(
-    0,
-    20000,
+  @IsPositive(
     {
       message: (args: ValidationArguments) => {
         return CheckCatalogService.formatResultMessage('RATA-18-B', {
@@ -122,8 +120,6 @@ export class RataSummaryBaseDTO {
         });
       },
     },
-    false,
-    false,
   )
   meanRATAReferenceValue?: number;
 

--- a/src/rata-summary-workspace/rata-summary-checks.service.ts
+++ b/src/rata-summary-workspace/rata-summary-checks.service.ts
@@ -213,7 +213,7 @@ export class RataSummaryChecksService {
         key: KEY,
         fieldname: 'meanCEMValue',
       });
-    } else if (meanCEMValue <= 0 || meanCEMValue >= 20000) {
+    } else if (meanCEMValue <= 0) {
       error = CheckCatalogService.formatResultMessage('RATA-17-B', {
         key: KEY,
         fieldname: 'meanCEMValue',


### PR DESCRIPTION
Issue:
Rata-17-b and Rata-18-b checks are following the logic of the error messages instead of the specifications logic (All checks should follow the specifications logic regardless of what the error message says)