### PR TITLE
disabled LINEAR-4 check for imports

### DIFF
--- a/src/test-summary-workspace/test-summary-checks.service.spec.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.spec.ts
@@ -290,7 +290,7 @@ describe('Test Summary Check Service Test', () => {
       const result = await service.runChecks(locationId, payload, true, false, [
         payload,
       ]);
-      expect(result).toEqual([MOCK_ERROR_MSG, MOCK_ERROR_MSG, MOCK_ERROR_MSG]);
+      expect(result).toEqual([MOCK_ERROR_MSG, MOCK_ERROR_MSG]);
     });
 
     it('Should get error LINEAR -31 Duplicate Test Summary record (Result A)', async () => {
@@ -524,7 +524,7 @@ describe('Test Summary Check Service Test', () => {
       importPayload.endMinute = 1;
 
       try {
-        await service.runChecks(locationId, importPayload, true, false, [
+        await service.runChecks(locationId, importPayload, false, false, [
           importPayload,
         ]);
       } catch (err) {
@@ -536,7 +536,7 @@ describe('Test Summary Check Service Test', () => {
       jest.spyOn(repository, 'findOne').mockResolvedValue(new TestSummary());
 
       try {
-        await service.runChecks(locationId, payload, true, false, [payload]);
+        await service.runChecks(locationId, payload, false, false, [payload]);
       } catch (err) {
         expect(err.response.message).toEqual([MOCK_ERROR_MSG]);
       }
@@ -548,7 +548,7 @@ describe('Test Summary Check Service Test', () => {
         .mockResolvedValue(new TestSummary());
 
       try {
-        await service.runChecks(locationId, payload, true, false, [payload]);
+        await service.runChecks(locationId, payload, false, false, [payload]);
       } catch (err) {
         expect(err.response.message).toEqual([MOCK_ERROR_MSG]);
       }

--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -180,14 +180,16 @@ export class TestSummaryChecksService {
     if (!isUpdate) {
       if (summary.testTypeCode === TestTypeCodes.LINE) {
         // LINEAR-4 Identification of Previously Reported Test or Test Number for Linearity Check
-        error = await this.linear4Check(
-          locationId,
-          summary,
-          historicalTestSumId,
-          isImport,
-        );
-        if (error) {
-          errorList.push(error);
+        if(!isImport){
+          error = await this.linear4Check(
+            locationId,
+            summary,
+            historicalTestSumId,
+            isImport,
+          );
+          if (error) {
+            errorList.push(error);
+          }
         }
       }
 


### PR DESCRIPTION
Update the validations that check for Duplicate records when importing a QA/Cert

Notes:
When a user is importing a QA/Cert that is a duplicate, we will no longer prevent it from being imported by displaying the Duplicate Import Checks. In the future, we shall delete an existing record when a duplicate record is being imported.

The duplicate validations shall only be displayed/applicable when a user is manually creating a record

The scope of this ticket is for the below validations:

Only Linear-4 check was implemented

APPE-4: Identification of Previously Reported Test or Test Number for Appendix E Test
CYCLE-5: Identification of Previously Reported Test or Test Number for Cycle Time Test
F2LCHK-14: Identification of Previously Reported Test or Test Number for Flow to Load Check
F2LREF-2: Identification of Previously Reported Test or Test Number for Flow to Load Reference Data
FFACC-3: Identification of Previously Reported Test or Number for Fuel Flowmeter Accuracy Test
FFACCTT-4: Identification of Previously Reported Test or Number for Transmitter Transducer Test
FF2LBAS-2: Identification of Previously Reported Test or Test Number for FuelFlow to Load Baseline Data
FF2LTST-2: Identification of Previously Reported Test or Test Number for FuelFlow to Load Test
LINEAR-4: Identification of Previously Reported Test or Test Number for Linearity Check
ONOFF-23: Identification of Previously Reported Test or Test Number for Online Offline Calibration Test
RATA-49: Identification of Previously Reported Test or Test Number for RATA
SEVNDAY-5: Identification of Previously Reported Test or Test Number for 7-Day Calibration Test
TEST-20 : Identification of Previously Reported Test or Test Number for Miscellaneous Test
UNITDEF-6: Identification of Previously Reported Test or Test Number for Unit Default Test