### PR TITLE
Bug/5144 rata 120

### DIFF
--- a/src/test-qualification-workspace/test-qualification-checks.service.spec.ts
+++ b/src/test-qualification-workspace/test-qualification-checks.service.spec.ts
@@ -483,40 +483,6 @@ describe('TestQualificationChecksService', () => {
         expect(err.response.message).toEqual([MOCK_ERROR_MSG]);
       }
     });
-
-    it('Should get [RATA-120-C] error', async () => {
-      payload.testClaimCode = 'SLC';
-      payload.endDate = new Date('2020-01-01');
-
-      let testSumRec = new TestSummary();
-      testSumRecord.beginDate = new Date('2020-01-01');
-
-      const returnValue = new TestQualification();
-      jest.spyOn(repository, 'find').mockResolvedValue([returnValue]);
-
-      const monSysRec = new MonitorSystem();
-      monSysRec.systemTypeCode = 'FLOW';
-      jest
-        .spyOn(monitorSystemRepository, 'findOne')
-        .mockResolvedValue(monSysRec);
-      jest
-        .spyOn(testSummaryRepository, 'getTestSummaryById')
-        .mockResolvedValue(testSumRec);
-
-      try {
-        await service.runChecks(
-          locationId,
-          payload,
-          testQualificationRecords,
-          testSumId,
-          testSumRecord,
-          rata,
-          true,
-        );
-      } catch (err) {
-        expect(err.response.message).toEqual([MOCK_ERROR_MSG]);
-      }
-    });
   });
 
   describe('RATA-121 Duplicate Test Claim', () => {

--- a/src/test-qualification-workspace/test-qualification-checks.service.ts
+++ b/src/test-qualification-workspace/test-qualification-checks.service.ts
@@ -245,18 +245,6 @@ export class TestQualificationChecksService {
         error = this.getErrorMessage('RATA-120-B');
         errors.push(error);
       }
-
-      if (
-        testSumBeginDate !== null &&
-        testQualification.endDate <= testSumBeginDate
-      ) {
-        error = this.getErrorMessage('RATA-120-C', {
-          datefield1: testSumBeginDate,
-          datefield2: testQualification.endDate,
-          key: KEY,
-        });
-        errors.push(error);
-      }
     }
 
     return errors;


### PR DESCRIPTION
Issue:
Looks like RATA-120-C's logic is incorrect and it is preventing a user from a successful Import for Test Qualification

Steps to Recreate:

Login to ECMPS and access the Export functionality
Select and export QA & Certification file for the Configuration: Ames
Now navigate to Test Data module, access and checkout the same Configuration: Ames
Click Import and select Import from File. Add the file you previously imported which has Test Qualification data with correct dates.
Click Import: You will notice that the system displays RATA-120-C validation even though it is not applicable

Resolution:
Removed broken RATA-120 check from checks service since check is already working in DTO