### PR TITLE
5099 - Only Check Date Consistency if Begin & End Exist

### DIFF
--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -145,9 +145,11 @@ export class TestSummaryChecksService {
 
     // TEST-7 Test Dates Consistent
     // NOTE: beginMinute and endMinute validity tests need to run before this test
-    error = this.test7Check(summary);
-    if (error) {
-      errorList.push(error);
+    if(summary.beginDate && summary.endDate) {
+      error = this.test7Check(summary);
+      if (error) {
+        errorList.push(error);
+      }
     }
 
     if (summary.testTypeCode === TestTypeCodes.LINE) {


### PR DESCRIPTION
Skips Begin / End Date consistency check for Test Summary when both dates aren't provided for a test type (some test types have ONLY begin or end date, or neither).