### PR TITLE
Add DTO Validation Requiring TestTypeCode

### DIFF
--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -147,6 +147,14 @@ export class TestSummaryBaseDTO {
   @ApiProperty({
     description: 'Test Type Code. ADD TO PROPERTY METADATA',
   })
+  @IsNotEmpty({
+    message: (args: ValidationArguments) => {
+      return CheckCatalogService.formatResultMessage('TEST-12-A', {
+      fieldname: args.property,
+      key: KEY,
+      });
+    }
+  })
   @IsValidCode(TestTypeCode, {
     message: (args: ValidationArguments) => {
       return CheckCatalogService.formatMessage(


### PR DESCRIPTION
Adds DTO Validation for TestSummary requiring a TestTypeCode.  The UI allows submission without selecting a TestTypeCode and this resulted in a 500 error on the API side.