### PR TITLE
feature/5508 - Validate Upload File Type and Size

### DIFF
--- a/src/s3-file-upload/s3-file-upload.controller.spec.ts
+++ b/src/s3-file-upload/s3-file-upload.controller.spec.ts
@@ -3,6 +3,19 @@ import { S3FileUploadController } from './s3-file-upload.controller';
 import { ConfigService } from '@nestjs/config';
 import { S3FileUploadService } from './s3-file-upload.service';
 
+const file = {
+  originalname: 'sample.name',
+  mimetype: 'application/pdf',
+  path: 'sample.url',
+  buffer: Buffer.from('test'),
+  fieldname: 'sample.fieldname',
+  encoding: 'sample.encoding',
+  size: 1000,
+  stream: null,
+  destination:'sample.destination',
+  filename: 'sample.filename'
+};
+
 describe('S3FileUploadController', () => {
   let controller: S3FileUploadController;
   let service: S3FileUploadService;
@@ -32,22 +45,30 @@ describe('S3FileUploadController', () => {
   });
 
   it('should be defined', async () => {
-    const file = {
-      originalname: 'sample.name',
-      mimetype: 'sample.type',
-      path: 'sample.url',
-      buffer: Buffer.from('test'),
-      fieldname: 'sample.fieldname',
-      encoding: 'sample.encoding',
-      size: 1000,
-      stream: null,
-      destination:'sample.destination',
-      filename: 'sample.filename'
-    };
-
     jest.spyOn(configService, 'get').mockReturnValue("value");
     jest.spyOn(service, 'uploadFile').mockResolvedValue(null);
     await expect( controller.uploadFile(file)).resolves;
 
   });
+
+  it('Should fail if mime type is not pdf or xml', async() => {
+    jest.spyOn(service, 'uploadFile').mockResolvedValue(null);
+
+    const testFile = {...file, mimetype: 'text/xml'};
+    expect(controller.uploadFile(testFile));
+
+    testFile.mimetype = 'application/xml';
+    expect(controller.uploadFile(testFile));
+
+    testFile.mimetype = 'application/pdf';
+    expect(controller.uploadFile(testFile));
+
+    testFile.mimetype='image/png'
+    expect(() => controller.uploadFile(testFile)).toThrowError();
+  })
+
+  it('Should fail if file size is > 30M', async () => {
+    const testFile = {...file, size: (30 * 1024 * 1024 + 1)};
+    expect(() => controller.uploadFile(testFile)).toThrowError();
+  })
 });

--- a/src/s3-file-upload/s3-file-upload.controller.ts
+++ b/src/s3-file-upload/s3-file-upload.controller.ts
@@ -1,12 +1,17 @@
-import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import {Controller, HttpStatus, Post, UploadedFile, UseInterceptors} from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBody, ApiConsumes, ApiSecurity, ApiTags } from '@nestjs/swagger';
 import { S3FileUploadService } from './s3-file-upload.service';
+import {EaseyException} from "@us-epa-camd/easey-common/exceptions";
+
+const MAX_UPLOAD_SIZE_MB: number = 30;
 
 @Controller()
 @ApiTags("File Upload")
 @ApiSecurity('APIKey')
 export class S3FileUploadController {
+
+
 
     constructor(private service: S3FileUploadService) {}
 
@@ -25,6 +30,19 @@ export class S3FileUploadController {
       })
     @UseInterceptors(FileInterceptor('file'))
     uploadFile(@UploadedFile() file: Express.Multer.File) {
+        const fileErrors = [];
+        if(file.size > MAX_UPLOAD_SIZE_MB * 1024 * 1024)
+            fileErrors.push(`Uploaded file exceeds maximum size of ${MAX_UPLOAD_SIZE_MB}M`);
+        if(! ['application/pdf','application/xml','text/xml'].includes(file.mimetype))
+            fileErrors.push('Only XML and PDF files may be uploaded');
+
+        if(fileErrors.length > 0)
+            throw new EaseyException(
+                new Error(fileErrors.join('\n')),
+                HttpStatus.BAD_REQUEST,
+                { responseObject: fileErrors }
+            )
+
         this.service.uploadFile(file.originalname, file.buffer)
     }
 }


### PR DESCRIPTION
Validates the S3 File Upload to ensure it is not > 30M in size and is a PDF or XML MimeType