### PR TITLE
Bug: update protocol-gas findOne query

### DIFF
--- a/src/protocol-gas-workspace/protocol-gas.service.ts
+++ b/src/protocol-gas-workspace/protocol-gas.service.ts
@@ -158,7 +158,7 @@ export class ProtocolGasWorkspaceService {
       historicalRecord = await this.historicalRepo.findOne({
         testSumId: testSumId,
         gasLevelCode: payload.gasLevelCode,
-        cylinderIdentifier: payload.cylinderIdentifier,
+        gasTypeCode: payload.gasTypeCode,
       });
     }
 

--- a/src/protocol-gas-workspace/protocol-gas.service.ts
+++ b/src/protocol-gas-workspace/protocol-gas.service.ts
@@ -158,6 +158,7 @@ export class ProtocolGasWorkspaceService {
       historicalRecord = await this.historicalRepo.findOne({
         testSumId: testSumId,
         gasLevelCode: payload.gasLevelCode,
+        cylinderIdentifier: payload.cylinderIdentifier,
         gasTypeCode: payload.gasTypeCode,
       });
     }


### PR DESCRIPTION
## used `gasTypeCode` to find a Historical record, because its a not null property.

![image](https://github.com/US-EPA-CAMD/easey-qa-certification-api/assets/102534033/e7a85bda-588a-4367-8b23-18b07d42e867)

