### PR TITLE
fix/5713 -QA Test Data Size Limit

### DIFF
--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -69,7 +69,7 @@ export default registerAs('app', () => ({
   published: getConfigValue('EASEY_QA_CERTIFICATION_API_PUBLISHED', 'local'),
   reqSizeLimit: getConfigValue(
     'EASEY_QA_CERTIFICATION_API_REQ_SIZE_LIMIT',
-    '1mb',
+    '50mb',
   ),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_QA_CERTIFICATION_API_ENABLE_DEBUG'),


### PR DESCRIPTION
App Config was limiting the POST/PUT data size to 1MB as a default.  This change makes the default 50MB.  The limit can be changed from the default by setting the ENV variable EASEY_QA_CERTIFICATION_API_REQ_SIZE_LIMIT, which is not currently set in any of the CF environments.