### PR TITLE
Fix Bug from Renamed DTO/Entity Prop Names

### DIFF
--- a/src/qa-certification-event-workspace/qa-certification-event-checks.service.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-checks.service.ts
@@ -80,7 +80,7 @@ export class QACertificationEventChecksService {
     const duplicateQACertEvent = this.getErrorMessage('QACERT-11-A', {
       recordtype: KEY,
       fieldnames:
-        'locationId, qaCertEventCode, qaCertEventHour, qaCertEventDate, monitoringSystemId, componentId',
+        'locationId, certificationEventCode, certificationEventHour, certificationEventDate, monitoringSystemId, componentId',
     });
 
     if (isImport) {

--- a/src/utilities/qa-cert-events.querybuilder.ts
+++ b/src/utilities/qa-cert-events.querybuilder.ts
@@ -42,7 +42,7 @@ export const addBeginAndEndDateWhere = (
         qb1.where(
           new Brackets(qb2 => {
             qb2.andWhere(
-              'qce.qaCertEventDate BETWEEN :beginDate AND :endDate',
+              'qce.certificationEventDate BETWEEN :beginDate AND :endDate',
               {
                 beginDate,
                 endDate,


### PR DESCRIPTION
Recent change to entity and dto property names for QACertEvent missed updating a querybuilder reference to one of those props. 