### PR TITLE
Make Vendor ID Optional for Protocol Gas

### DIFF
--- a/src/dto/protocol-gas.dto.ts
+++ b/src/dto/protocol-gas.dto.ts
@@ -73,11 +73,7 @@ export class ProtocolGasBaseDTO {
   })
   cylinderIdentifier?: string;
 
-  @IsNotEmpty({
-    message: (args: ValidationArguments) => {
-      return `The value of [${args.value}] for [${args.property}] must not be empty`;
-    },
-  })
+  @IsOptional()
   @IsString()
   @MatchesRegEx('([A-Z0-9]{1,8})*', {
     message: (args: ValidationArguments) => {


### PR DESCRIPTION
Previous ticket had mistakenly requested that Vendor ID be required for Protocol Gas, but it should not be.  There are >72K records in Official with null Vendor ID.