### PR TITLE
Fix/6102 forbidden resource errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 # dependencies
 /node_modules
 /npm-packages-offline-cache
+.npmrc
 
 # production
 /dist

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ package-lock.json
 .DS_Store
 .env
 .env.*
+.envrc
 
 npm-debug.log*
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "8.0.3",
     "@types/multer": "^1.4.7",
-    "@us-epa-camd/easey-common": "^17.2.8",
+    "@us-epa-camd/easey-common": "^17.2.12",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",

--- a/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
+++ b/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
@@ -82,7 +82,7 @@ export class AirEmissionTestingWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -109,7 +109,7 @@ export class AirEmissionTestingWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -138,7 +138,7 @@ export class AirEmissionTestingWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.controller.ts
+++ b/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.controller.ts
@@ -85,7 +85,7 @@ export class AppECorrelationTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -116,7 +116,7 @@ export class AppECorrelationTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -147,7 +147,7 @@ export class AppECorrelationTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.controller.ts
+++ b/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.controller.ts
@@ -82,7 +82,7 @@ export class AppendixETestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -106,7 +106,7 @@ export class AppendixETestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -135,7 +135,7 @@ export class AppendixETestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.controller.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.controller.ts
@@ -85,7 +85,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -117,7 +117,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -149,7 +149,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
@@ -87,7 +87,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -120,7 +120,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -153,7 +153,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
@@ -77,7 +77,7 @@ export class CalibrationInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -103,7 +103,7 @@ export class CalibrationInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -131,7 +131,7 @@ export class CalibrationInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -73,8 +73,17 @@ export default registerAs('app', () => ({
   ),
   // ENABLES DEBUG CONSOLE LOGS
   enableDebug: getConfigValueBoolean('EASEY_QA_CERTIFICATION_API_ENABLE_DEBUG'),
-  // NEEDS TO BE SET IN .ENV FILE FOR LOCAL DEVELOPMENT
-  // FORMAT: { "userId": "", "roles": [ { "orisCode": 3, "role": "P" } ] }
+  /**
+   * Needs to be set in .env file for local development if `EASEY_EMISSIONS_API_ENABLE_AUTH_TOKEN` is false.
+   * Format:
+   *   {
+   *       "facilities": [
+   *           { "facId": number, "orisCode": number, "permissions": string[] }
+   *       ],
+   *       "roles": <"Preparer" | "Submitter" | "Sponsor">[],
+   *       "userId": string
+   *   }
+   */
   currentUser: getConfigValue(
     'EASEY_QA_CERTIFICATION_API_CURRENT_USER',
     '{ "userId": "" }',

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.controller.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.controller.ts
@@ -83,7 +83,7 @@ export class CycleTimeInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -118,7 +118,7 @@ export class CycleTimeInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -154,7 +154,7 @@ export class CycleTimeInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.controller.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.controller.ts
@@ -77,7 +77,7 @@ export class CycleTimeSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -99,7 +99,7 @@ export class CycleTimeSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -127,7 +127,7 @@ export class CycleTimeSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
@@ -87,7 +87,7 @@ export class FlowRataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -129,7 +129,7 @@ export class FlowRataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -171,7 +171,7 @@ export class FlowRataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/flow-to-load-check-workspace/flow-to-load-check-workspace.controller.ts
+++ b/src/flow-to-load-check-workspace/flow-to-load-check-workspace.controller.ts
@@ -78,7 +78,7 @@ export class FlowToLoadCheckWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -100,7 +100,7 @@ export class FlowToLoadCheckWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -129,7 +129,7 @@ export class FlowToLoadCheckWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/flow-to-load-reference-workspace/flow-to-load-reference-workspace.controller.ts
+++ b/src/flow-to-load-reference-workspace/flow-to-load-reference-workspace.controller.ts
@@ -79,7 +79,7 @@ export class FlowToLoadReferenceWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -105,7 +105,7 @@ export class FlowToLoadReferenceWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -133,7 +133,7 @@ export class FlowToLoadReferenceWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
@@ -80,7 +80,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -106,7 +106,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -134,7 +134,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
@@ -77,7 +77,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -103,7 +103,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -131,7 +131,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.controller.ts
+++ b/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.controller.ts
@@ -80,7 +80,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -106,7 +106,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -134,7 +134,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/hg-injection-workspace/hg-injection-workspace.controller.ts
+++ b/src/hg-injection-workspace/hg-injection-workspace.controller.ts
@@ -72,7 +72,7 @@ export class HgInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -100,7 +100,7 @@ export class HgInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -124,7 +124,7 @@ export class HgInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/hg-summary-workspace/hg-summary-workspace.controller.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.controller.ts
@@ -73,7 +73,7 @@ export class HgSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -95,7 +95,7 @@ export class HgSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -118,7 +118,7 @@ export class HgSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/linearity-injection-workspace/linearity-injection.controller.ts
+++ b/src/linearity-injection-workspace/linearity-injection.controller.ts
@@ -86,7 +86,7 @@ export class LinearityInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -115,7 +115,7 @@ export class LinearityInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -146,7 +146,7 @@ export class LinearityInjectionWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/linearity-summary-workspace/linearity-summary.controller.ts
+++ b/src/linearity-summary-workspace/linearity-summary.controller.ts
@@ -83,7 +83,7 @@ export class LinearitySummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -106,7 +106,7 @@ export class LinearitySummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -130,7 +130,7 @@ export class LinearitySummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
@@ -81,7 +81,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -108,7 +108,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -133,7 +133,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/protocol-gas-workspace/protocol-gas.controller.ts
+++ b/src/protocol-gas-workspace/protocol-gas.controller.ts
@@ -82,7 +82,7 @@ export class ProtocolGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -111,7 +111,7 @@ export class ProtocolGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -141,7 +141,7 @@ export class ProtocolGasWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.controller.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.controller.ts
@@ -82,7 +82,7 @@ export class QACertificationEventWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -104,7 +104,7 @@ export class QACertificationEventWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -127,7 +127,7 @@ export class QACertificationEventWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/qa-certification-workspace/qa-certification.controller.ts
+++ b/src/qa-certification-workspace/qa-certification.controller.ts
@@ -102,7 +102,7 @@ export class QACertificationWorkspaceController {
       ],
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/rata-run-workspace/rata-run-workspace.controller.ts
+++ b/src/rata-run-workspace/rata-run-workspace.controller.ts
@@ -85,7 +85,7 @@ export class RataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -124,7 +124,7 @@ export class RataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -147,7 +147,7 @@ export class RataRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/rata-summary-workspace/rata-summary-workspace.controller.ts
+++ b/src/rata-summary-workspace/rata-summary-workspace.controller.ts
@@ -82,7 +82,7 @@ export class RataSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -118,7 +118,7 @@ export class RataSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -150,7 +150,7 @@ export class RataSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/rata-traverse-workspace/rata-traverse-workspace.controller.ts
+++ b/src/rata-traverse-workspace/rata-traverse-workspace.controller.ts
@@ -89,7 +89,7 @@ export class RataTraverseWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -131,7 +131,7 @@ export class RataTraverseWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -169,7 +169,7 @@ export class RataTraverseWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/rata-workspace/rata-workspace.controller.ts
+++ b/src/rata-workspace/rata-workspace.controller.ts
@@ -76,7 +76,7 @@ export class RataWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -99,7 +99,7 @@ export class RataWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -129,7 +129,7 @@ export class RataWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
@@ -79,7 +79,7 @@ export class TestExtensionExemptionsWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -105,7 +105,7 @@ export class TestExtensionExemptionsWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -133,7 +133,7 @@ export class TestExtensionExemptionsWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/test-qualification-workspace/test-qualification-workspace.controller.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.controller.ts
@@ -81,7 +81,7 @@ export class TestQualificationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -117,7 +117,7 @@ export class TestQualificationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -155,7 +155,7 @@ export class TestQualificationWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/test-summary-workspace/test-summary.controller.ts
+++ b/src/test-summary-workspace/test-summary.controller.ts
@@ -97,7 +97,7 @@ export class TestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -119,7 +119,7 @@ export class TestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -142,7 +142,7 @@ export class TestSummaryWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.controller.ts
+++ b/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.controller.ts
@@ -83,7 +83,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -110,7 +110,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -138,7 +138,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/unit-default-test-run-workspace/unit-default-test-run.controller.ts
+++ b/src/unit-default-test-run-workspace/unit-default-test-run.controller.ts
@@ -85,7 +85,7 @@ export class UnitDefaultTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -120,7 +120,7 @@ export class UnitDefaultTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -156,7 +156,7 @@ export class UnitDefaultTestRunWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/src/unit-default-test-workspace/unit-default-test-workspace.controller.ts
+++ b/src/unit-default-test-workspace/unit-default-test-workspace.controller.ts
@@ -79,7 +79,7 @@ export class UnitDefaultTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -101,7 +101,7 @@ export class UnitDefaultTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )
@@ -130,7 +130,7 @@ export class UnitDefaultTestWorkspaceController {
     {
       pathParam: 'locId',
       requiredRoles: ['Preparer', 'Submitter', 'Sponsor'],
-      permissionsForFacility: ['DSQA', 'DPQA'],
+      permissionsForFacility: ['DSQA'],
     },
     LookupType.Location,
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,10 +2221,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@^17.2.8":
-  version "17.2.8"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.8/13f168b52cd98fdf4047c60abef4f233fce16ba7#13f168b52cd98fdf4047c60abef4f233fce16ba7"
-  integrity sha512-OUh0NCDlfLqMMUNx4FAYkBk6+vfQeRITQEc1BTf3JZVTxSdff7+Pdowg2mJ/uAB83iNAGrSQgtmKzGQdxSvKdA==
+"@us-epa-camd/easey-common@^17.2.12":
+  version "17.2.12"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.2.12/68bb9cc590a6375b56c3a2457c27d42479e978f4#68bb9cc590a6375b56c3a2457c27d42479e978f4"
+  integrity sha512-dYMdWPTdqNc0fvpk1UajksdlE7uA/KccRr529bobxHNG2y9a5b9DWiNaRt9BwtTFpy2OSgWQqJF+LO/ENwu87w==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Main Changes

- Removed values from the `permissionsForFacility` array that are no longer returned from the permissions API (`DPQA`).
- Updated the comment documenting the `EASEY_QA_CERTIFICATION_API_CURRENT_USER` environment variable.

## Note
These updates were made while working on https://github.com/US-EPA-CAMD/easey-ui/issues/6102, but they are not needed to resolve that ticket (the actual fix is in [`US-EPA-CAMD/easey-common#137`](https://github.com/US-EPA-CAMD/easey-common/pull/137)).