### PR TITLE
Fix/#6024 import flow rata historical

### DIFF
--- a/src/flow-rata-run-workspace/flow-rata-run-checks.service.spec.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-checks.service.spec.ts
@@ -184,6 +184,7 @@ describe('Flow Rata Run Check Service Test', () => {
   describe('RATA-115 Average Velocity Without Wall Effects Valid', () => {
     it('Should get [RATA-115-A] error', async () => {
       importPayload.averageVelocityWithoutWallEffects = 0;
+      importPayload.calculatedWAF = null;
 
       try {
         await service.runChecks(

--- a/src/flow-rata-run-workspace/flow-rata-run-checks.service.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-checks.service.ts
@@ -74,7 +74,7 @@ export class FlowRataRunChecksService {
     if (testSumRecord.testTypeCode === TestTypeCodes.RATA) {
       error = this.rata114Check(
         rataSummaryRecord,
-        flowRataRun.averageVelocityWithWallEffects,
+        flowRataRun
       );
       if (error) {
         errorList.push(error);
@@ -137,13 +137,13 @@ export class FlowRataRunChecksService {
 
   private rata114Check(
     rataSummaryRecord: RataSummary,
-    averageVelocityWithWallEffects: number,
+    flowRataRun: FlowRataRunBaseDTO | FlowRataRunImportDTO,
   ): string {
     let error: string = null;
     let FIELDNAME: string = 'averageVelocityWithWallEffects';
     if (
-      averageVelocityWithWallEffects !== null ||
-      averageVelocityWithWallEffects === 0
+      flowRataRun.averageVelocityWithWallEffects !== null ||
+      flowRataRun.averageVelocityWithWallEffects === 0
     ) {
       if (
         ['2F', '2G', '2FJ', '2GJ'].includes(
@@ -155,8 +155,8 @@ export class FlowRataRunChecksService {
           key: KEY,
         });
       } else if (
-        averageVelocityWithWallEffects <= 0 ||
-        averageVelocityWithWallEffects >= 20000
+        flowRataRun.averageVelocityWithWallEffects <= 0 ||
+        flowRataRun.averageVelocityWithWallEffects >= 20000
       ) {
         error = this.getMessage('RATA-114-B', {
           fieldname: FIELDNAME,
@@ -166,7 +166,7 @@ export class FlowRataRunChecksService {
     } else {
       if (
         rataSummaryRecord.referenceMethodCode === 'M2H' ||
-        rataSummaryRecord.calculatedWAF
+        flowRataRun.calculatedWAF
       ) {
         error = this.getMessage('RATA-114-C', {
           fieldname: FIELDNAME,

--- a/src/rata-traverse-workspace/rata-traverse-checks.service.ts
+++ b/src/rata-traverse-workspace/rata-traverse-checks.service.ts
@@ -159,8 +159,7 @@ export class RataTraverseChecksService {
 
     if (rataTraverse.probeTypeCode) {
       if (
-        rataSumRecord.referenceMethodCode &&
-        rataSumRecord.referenceMethodCode.startsWith('2F')
+        rataSumRecord.referenceMethodCode?.startsWith('2F')
       ) {
         if (
           !['PRISM', 'PRISM-T', 'SPHERE'].includes(rataTraverse.probeTypeCode)
@@ -172,8 +171,7 @@ export class RataTraverseChecksService {
           });
         }
       } else if (
-        rataSumRecord.referenceMethodCode &&
-        rataSumRecord.referenceMethodCode.startsWith('2G')
+        rataSumRecord.referenceMethodCode?.startsWith('2G')
       ) {
         if (rataTraverse.probeTypeCode === 'PRANDT1') {
           error = this.getMessage('RATA-72-B', {
@@ -277,7 +275,7 @@ export class RataTraverseChecksService {
     let error: string = null;
     const fieldname = 'pitchAngle';
 
-    if (referenceMethodCode && referenceMethodCode.startsWith('2F')) {
+    if (referenceMethodCode?.startsWith('2F')) {
       if (pitchAngle === null || pitchAngle === undefined) {
         error = this.getMessage('RATA-79-A', {
           fieldname,

--- a/src/rata-traverse-workspace/rata-traverse-checks.service.ts
+++ b/src/rata-traverse-workspace/rata-traverse-checks.service.ts
@@ -246,7 +246,7 @@ export class RataTraverseChecksService {
       (referenceMethodCode.startsWith('2F') ||
         referenceMethodCode.startsWith('2G'))
     ) {
-      if (!yawAngle) {
+      if (yawAngle === null || yawAngle === undefined) {
         error = this.getMessage('RATA-78-A', {
           key: KEY,
         });


### PR DESCRIPTION
## Ticket
[RATA-78-A and RATA-114-C when importing Flow RATA from historical](https://github.com/US-EPA-CAMD/easey-ui/issues/6024)

## Changes

- RATA-78-A: `yawAngle` is a number type, so check with null or undefined 
- RATA-114-A: Checked `calculatedWAF` from Flow RATA Run record.
- Updated test case
- Code refactored as per the sonarcloud
