### PR TITLE
Fix/5992 APPE schema issues

### DIFF
--- a/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.spec.ts
+++ b/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.spec.ts
@@ -244,10 +244,10 @@ describe('AppECorrelationTestRunWorkspaceService', () => {
     });
 
     it('Should Import Appendix E Corrleation Test Run from Historical Record', async () => {
-      importDTO.appEHeatInputFromGasData = [
+      importDTO.appendixEHeatInputFromGasData = [
         new AppEHeatInputFromGasImportDTO(),
       ];
-      importDTO.appEHeatInputFromOilData = [
+      importDTO.appendixEHeatInputFromOilData = [
         new AppEHeatInputFromOilImportDTO(),
       ];
 

--- a/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.ts
+++ b/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.service.ts
@@ -198,8 +198,8 @@ export class AppECorrelationTestRunWorkspaceService {
       `Appendix E Correlation Test Run Successfully Imported. Record Id: ${createdTestRun.id}`,
     );
 
-    if (payload.appEHeatInputFromGasData?.length > 0) {
-      for (const appEHeatInputFromGas of payload.appEHeatInputFromGasData) {
+    if (payload.appendixEHeatInputFromGasData?.length > 0) {
+      for (const appEHeatInputFromGas of payload.appendixEHeatInputFromGasData) {
         promises.push(
           this.appEHeatInputFromGasService.import(
             locationId,
@@ -213,8 +213,8 @@ export class AppECorrelationTestRunWorkspaceService {
       }
     }
 
-    if (payload.appEHeatInputFromOilData?.length > 0) {
-      for (const appEHeatInputFromOil of payload.appEHeatInputFromOilData) {
+    if (payload.appendixEHeatInputFromOilData?.length > 0) {
+      for (const appEHeatInputFromOil of payload.appendixEHeatInputFromOilData) {
         promises.push(
           this.appEHeatInputFromOilService.import(
             locationId,
@@ -256,10 +256,10 @@ export class AppECorrelationTestRunWorkspaceService {
       const hIOil = await this.appEHeatInputFromOilService.export(testRunIds);
 
       appECorrelationTestRuns.forEach(s => {
-        s.appEHeatInputFromGasData = hIGas.filter(
+        s.appendixEHeatInputFromGasData = hIGas.filter(
           i => i.appECorrTestRunId === s.id,
         );
-        s.appEHeatInputFromOilData = hIOil.filter(
+        s.appendixEHeatInputFromOilData = hIOil.filter(
           i => i.appECorrTestRunId === s.id,
         );
       });

--- a/src/app-e-correlation-test-run/app-e-correlation-test-run.service.ts
+++ b/src/app-e-correlation-test-run/app-e-correlation-test-run.service.ts
@@ -72,10 +72,10 @@ export class AppECorrelationTestRunService {
       const hIOil = await this.appEHeatInputFromOilService.export(testRunIds);
 
       appECorrelationTestRuns.forEach(s => {
-        s.appEHeatInputFromGasData = hIGas.filter(
+        s.appendixEHeatInputFromGasData = hIGas.filter(
           i => i.appECorrTestRunId === s.id,
         );
-        s.appEHeatInputFromOilData = hIOil.filter(
+        s.appendixEHeatInputFromOilData = hIOil.filter(
           i => i.appECorrTestRunId === s.id,
         );
       });

--- a/src/dto/app-e-correlation-test-run.dto.ts
+++ b/src/dto/app-e-correlation-test-run.dto.ts
@@ -250,14 +250,14 @@ export class AppECorrelationTestRunRecordDTO extends AppECorrelationTestRunBaseD
 export class AppECorrelationTestRunImportDTO extends AppECorrelationTestRunBaseDTO {
   @ValidateNested({ each: true })
   @Type(() => AppEHeatInputFromOilImportDTO)
-  appEHeatInputFromOilData: AppEHeatInputFromOilImportDTO[];
+  appendixEHeatInputFromOilData: AppEHeatInputFromOilImportDTO[];
 
   @ValidateNested({ each: true })
   @Type(() => AppEHeatInputFromGasImportDTO)
-  appEHeatInputFromGasData: AppEHeatInputFromGasImportDTO[];
+  appendixEHeatInputFromGasData: AppEHeatInputFromGasImportDTO[];
 }
 
 export class AppECorrelationTestRunDTO extends AppECorrelationTestRunRecordDTO {
-  appEHeatInputFromOilData: AppEHeatInputFromOilDTO[];
-  appEHeatInputFromGasData: AppEHeatInputFromGasDTO[];
+  appendixEHeatInputFromOilData: AppEHeatInputFromOilDTO[];
+  appendixEHeatInputFromGasData: AppEHeatInputFromGasDTO[];
 }

--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -799,7 +799,7 @@ export class TestSummaryImportDTO extends TestSummaryBaseDTO {
 
   @ValidateNested({ each: true })
   @Type(() => AirEmissionTestingImportDTO)
-  airEmissionTestData: AirEmissionTestingImportDTO[];
+  airEmissionTestingData: AirEmissionTestingImportDTO[];
 }
 
 export class TestSummaryDTO extends TestSummaryRecordDTO {
@@ -819,5 +819,5 @@ export class TestSummaryDTO extends TestSummaryRecordDTO {
   hgSummaryData: HgSummaryDTO[];
   testQualificationData: TestQualificationDTO[];
   protocolGasData: ProtocolGasDTO[];
-  airEmissionTestData: AirEmissionTestingDTO[];
+  airEmissionTestingData: AirEmissionTestingDTO[];
 }

--- a/src/maps/app-e-correlation-test-run.map.ts
+++ b/src/maps/app-e-correlation-test-run.map.ts
@@ -48,8 +48,8 @@ export class AppECorrelationTestRunMap extends BaseMap<
       userId: entity.userId,
       addDate: entity.addDate ? entity.addDate.toISOString() : null,
       updateDate: entity.updateDate ? entity.updateDate.toISOString() : null,
-      appEHeatInputFromOilData: appEHeatInputFromOils,
-      appEHeatInputFromGasData: appEHeatInputFromGases,
+      appendixEHeatInputFromOilData: appEHeatInputFromOils,
+      appendixEHeatInputFromGasData: appEHeatInputFromGases,
     };
   }
 }

--- a/src/maps/test-summary.map.ts
+++ b/src/maps/test-summary.map.ts
@@ -157,7 +157,7 @@ export class TestSummaryMap extends BaseMap<TestSummary, TestSummaryDTO> {
       hgSummaryData: hgSummary,
       testQualificationData: testQuals,
       protocolGasData: protocolGases,
-      airEmissionTestData: airEmissionTestings,
+      airEmissionTestingData: airEmissionTestings,
     };
   }
 }

--- a/src/qa-certification-workspace/qa-certification-checks.service.ts
+++ b/src/qa-certification-workspace/qa-certification-checks.service.ts
@@ -341,7 +341,7 @@ export class QACertificationChecksService {
                 promises.push(
                   new Promise((resolve, _reject) => {
                     const results = this.appEGasChecksService.runImportChecks(
-                      appETestRun.appEHeatInputFromGasData,
+                      appETestRun.appendixEHeatInputFromGasData,
                     );
                     resolve(results);
                   }),
@@ -350,7 +350,7 @@ export class QACertificationChecksService {
                 promises.push(
                   new Promise((resolve, _reject) => {
                     const results = this.appEOilChecksService.runImportChecks(
-                      appETestRun.appEHeatInputFromOilData,
+                      appETestRun.appendixEHeatInputFromOilData,
                     );
                     resolve(results);
                   }),

--- a/src/qa-certification-workspace/qa-certification.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification.service.spec.ts
@@ -73,7 +73,7 @@ testSummary.unitDefaultTestData = [unitDefaultTest];
 testSummary.hgSummaryData = [hgSummary];
 testSummary.testQualificationData = [testQualification];
 testSummary.protocolGasData = [protocolGas];
-testSummary.airEmissionTestData = [airEmissionTesting];
+testSummary.airEmissionTestingData = [airEmissionTesting];
 qaCertDto.testExtensionExemptionData = [testExtExmtDto];
 qaCertDto.certificationEventData = [qaCertEventDto];
 

--- a/src/test-summary-workspace/test-summary-checks.service.spec.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.spec.ts
@@ -376,7 +376,7 @@ describe('Test Summary Check Service Test', () => {
         new AppECorrelationTestSummaryImportDTO(),
       ];
       importPayload.unitDefaultTestData = [new UnitDefaultTestImportDTO()];
-      importPayload.airEmissionTestData = [new AirEmissionTestingImportDTO()];
+      importPayload.airEmissionTestingData = [new AirEmissionTestingImportDTO()];
 
       try {
         await service.runChecks(locationId, importPayload, true, false, [

--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -343,7 +343,7 @@ export class TestSummaryChecksService {
         TestTypeCodes.APPE.toString(),
         TestTypeCodes.UNITDEF.toString(),
       ].includes(summary.testTypeCode) &&
-      summary.airEmissionTestData?.length > 0
+      summary.airEmissionTestingData?.length > 0
     ) {
       invalidChildRecords.push('Air Emission Test');
     }

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -121,7 +121,7 @@ export class TestSummaryWorkspaceService {
     delete dto.hgSummaryData;
     delete dto.testQualificationData;
     delete dto.protocolGasData;
-    delete dto.airEmissionTestData;
+    delete dto.airEmissionTestingData;
     delete dto.appendixECorrelationTestSummaryData;
 
     return dto;
@@ -263,7 +263,7 @@ export class TestSummaryWorkspaceService {
         );
         s.rataData = rataData.filter(i => i.testSumId === s.id);
         s.protocolGasData = protocolGasData.filter(i => i.testSumId === s.id);
-        s.appECorrelationTestSummaryData = appECorrelationTestSummaryData.filter(
+        s.appendixECorrelationTestSummaryData = appECorrelationTestSummaryData.filter(
           i => i.testSumId === s.id,
         );
         s.fuelFlowToLoadTestData = fuelFlowToLoadTestData.filter(
@@ -623,14 +623,14 @@ export class TestSummaryWorkspaceService {
     }
 
     if (
-      payload.airEmissionTestData?.length > 0 &&
+      payload.airEmissionTestingData?.length > 0 &&
       [
         TestTypeCodes.RATA.toString(),
         TestTypeCodes.UNITDEF.toString(),
         TestTypeCodes.APPE.toString(),
       ].includes(payload.testTypeCode)
     ) {
-      for (const airEmissionTesting of payload.airEmissionTestData) {
+      for (const airEmissionTesting of payload.airEmissionTestingData) {
         promises.push(
           this.airEmissionTestingWorkspaceService.import(
             createdTestSummary.id,
@@ -714,7 +714,7 @@ export class TestSummaryWorkspaceService {
     delete dto.hgSummaryData;
     delete dto.testQualificationData;
     delete dto.protocolGasData;
-    delete dto.airEmissionTestData;
+    delete dto.airEmissionTestingData;
 
     return dto;
   }

--- a/src/test-summary/test-summary.service.ts
+++ b/src/test-summary/test-summary.service.ts
@@ -97,7 +97,7 @@ export class TestSummaryService {
     delete dto.hgSummaryData;
     delete dto.testQualificationData;
     delete dto.protocolGasData;
-    delete dto.airEmissionTestData;
+    delete dto.airEmissionTestingData;
 
     return dto;
   }
@@ -272,7 +272,7 @@ export class TestSummaryService {
         s.testQualificationData = testQualificationData.filter(
           i => i.testSumId === s.id,
         );
-        s.airEmissionTestData = airEmissionTestData.filter(
+        s.airEmissionTestingData = airEmissionTestData.filter(
           i => i.testSumId === s.id,
         );
         s.hgSummaryData = hgSummaryData.filter(i => i.testSumId === s.id);

--- a/src/utilities/remove-non-reported-values.ts
+++ b/src/utilities/remove-non-reported-values.ts
@@ -78,7 +78,7 @@ async function removeTestSummaryNonReportedValues(
       removeHgSummaryNonReportedValues(dto.hgSummaryData),
       removeTestQualificationNonReportedValues(dto.testQualificationData),
       removeProtocolGasNonReportedValues(dto.protocolGasData),
-      removeAirEmissionTestingNonReportedValues(dto.airEmissionTestData),
+      removeAirEmissionTestingNonReportedValues(dto.airEmissionTestingData),
     );
     delete dto.id;
     delete dto.locationId;
@@ -381,8 +381,8 @@ async function removeAppECorrelationTestRunNonReportedValues(
   const promises = [];
   appECorrelationTestRunData?.forEach(dto => {
     promises.push(
-      removeAppEHeatInputFromOilNonReportedValues(dto.appEHeatInputFromOilData),
-      removeAppEHeatInputFromGasNonReportedValues(dto.appEHeatInputFromGasData),
+      removeAppEHeatInputFromOilNonReportedValues(dto.appendixEHeatInputFromOilData),
+      removeAppEHeatInputFromGasNonReportedValues(dto.appendixEHeatInputFromGasData),
     );
     delete dto.id;
     delete dto.appECorrTestSumId;


### PR DESCRIPTION
## Main Changes

- `airEmissionTestData` -> `airEmissionTestingData`
- `appECorrelationTestSummaryData` -> `appendixECorrelationTestSummaryData`
- `appEHeatInputFromGasData` -> `appendixEHeatInputFromGasData`
- `appEHeatInputFromOilData` -> `appendixEHeatInputFromOilData`

## Steps to Test

In the _QA & Certifications_ _Test Data_ module, test importing RATA & APPE data from historical, exporting from the _Export & Report_ module, then re-importing the file into the _Test Data_ module. Examples are:

### APPE

ORIS: 891 (Havana)
configuration: 1
period: 2007 Q3

### RATA

ORIS: 9 (Copper Station)
configuration: CTG-1
period: 2023 Q3

## NOTE

If running the `easey-content` API locally, be sure to use the `fix/5992-appe_schema_issues` branch. If pointed at the dev version of the API, https://github.com/US-EPA-CAMD/easey-content/pull/221 should be merged first.