### PR TITLE
Fix/6185 explicit nulls

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nestjs/swagger": "^5.1.2",
     "@nestjs/typeorm": "^8.0.3",
     "@types/multer": "^1.4.7",
-    "@us-epa-camd/easey-common": "17.4.0",
+    "@us-epa-camd/easey-common": "17.4.1",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",

--- a/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { CalibrationInjectionRepository } from '../calibration-injection/calibration-injection.repository';
@@ -188,13 +188,13 @@ export class CalibrationInjectionWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepository.findOneBy({
         testSumId: testSumId,
-        upscaleGasLevelCode: payload.upscaleGasLevelCode,
-        zeroInjectionDate: payload.zeroInjectionDate,
-        zeroInjectionHour: payload.zeroInjectionHour,
-        zeroInjectionMinute: payload.zeroInjectionMinute,
-        upscaleInjectionDate: payload.upscaleInjectionDate,
-        upscaleInjectionHour: payload.upscaleInjectionHour,
-        upscaleInjectionMinute: payload.upscaleInjectionMinute,
+        upscaleGasLevelCode: payload.upscaleGasLevelCode ?? IsNull(),
+        zeroInjectionDate: payload.zeroInjectionDate ?? IsNull(),
+        zeroInjectionHour: payload.zeroInjectionHour ?? IsNull(),
+        zeroInjectionMinute: payload.zeroInjectionMinute ?? IsNull(),
+        upscaleInjectionDate: payload.upscaleInjectionDate ?? IsNull(),
+        upscaleInjectionHour: payload.upscaleInjectionHour ?? IsNull(),
+        upscaleInjectionMinute: payload.upscaleInjectionMinute ?? IsNull(),
       });
     }
 

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { CycleTimeInjectionWorkspaceService } from '../cycle-time-injection-workspace/cycle-time-injection-workspace.service';
@@ -191,7 +191,7 @@ export class CycleTimeSummaryWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepository.findOneBy({
         testSumId: testSumId,
-        totalTime: payload.totalTime,
+        totalTime: payload.totalTime ?? IsNull(),
       });
     }
 

--- a/src/dto/test-summary.dto.ts
+++ b/src/dto/test-summary.dto.ts
@@ -280,7 +280,7 @@ export class TestSummaryBaseDTO {
       return `The value of [${args.value}] for [${args.property}] must be 1 to 3 characters and only consist of upper case letters, numbers for [${KEY}].`;
     },
   })
-  componentId?: string;
+  componentId: string;
 
   @ApiProperty({
     description: propertyMetadata.monitorSpanDTOSpanScaleCode.description,

--- a/src/flow-to-load-check-workspace/flow-to-load-check-workspace.service.ts
+++ b/src/flow-to-load-check-workspace/flow-to-load-check-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -176,7 +176,7 @@ export class FlowToLoadCheckWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
-        testBasisCode: payload.testBasisCode,
+        testBasisCode: payload.testBasisCode ?? IsNull(),
       });
     }
 

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -176,7 +176,7 @@ export class FuelFlowToLoadBaselineWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
-        accuracyTestNumber: payload.accuracyTestNumber,
+        accuracyTestNumber: payload.accuracyTestNumber ?? IsNull(),
       });
     }
 

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -156,7 +156,7 @@ export class FuelFlowToLoadTestWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
-        testBasisCode: payload.testBasisCode,
+        testBasisCode: payload.testBasisCode ?? IsNull(),
       });
     }
 

--- a/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.service.ts
+++ b/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -174,7 +174,7 @@ export class FuelFlowmeterAccuracyWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
-        accuracyTestMethodCode: payload.accuracyTestMethodCode,
+        accuracyTestMethodCode: payload.accuracyTestMethodCode ?? IsNull(),
       });
     }
 

--- a/src/linearity-injection-workspace/linearity-injection-checks.service.ts
+++ b/src/linearity-injection-workspace/linearity-injection-checks.service.ts
@@ -2,6 +2,7 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { IsNull } from 'typeorm';
 
 import {
   LinearityInjectionBaseDTO,
@@ -116,7 +117,7 @@ export class LinearityInjectionChecksService {
         {
           linSumId: linSumId,
           injectionDate: linearityInjection.injectionDate,
-          injectionHour: linearityInjection.injectionHour,
+          injectionHour: linearityInjection.injectionHour ?? IsNull(),
           injectionMinute: linearityInjection.injectionMinute,
         },
       );

--- a/src/linearity-injection-workspace/linearity-injection.service.ts
+++ b/src/linearity-injection-workspace/linearity-injection.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -79,7 +79,7 @@ export class LinearityInjectionWorkspaceService {
       historicalRecord = await this.historicalRepository.findOneBy({
         linSumId: linSumId,
         injectionDate: payload.injectionDate,
-        injectionHour: payload.injectionHour,
+        injectionHour: payload.injectionHour ?? IsNull(),
         injectionMinute: payload.injectionMinute,
       });
     }

--- a/src/qa-certification-event-workspace/qa-certification-event-checks.service.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-checks.service.ts
@@ -2,6 +2,7 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { IsNull } from 'typeorm';
 
 import {
   QACertificationEventBaseDTO,
@@ -116,10 +117,10 @@ export class QACertificationEventChecksService {
       qaCertEvents = await this.repository.findBy({
         locationId,
         certificationEventCode,
-        certificationEventHour,
+        certificationEventHour: certificationEventHour ?? IsNull(),
         certificationEventDate,
-        monitoringSystemRecordId,
-        componentRecordId,
+        monitoringSystemRecordId: monitoringSystemRecordId ?? IsNull(),
+        componentRecordId: componentRecordId ?? IsNull(),
       });
 
       if (qaCertEvents.length > 0) {

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.service.ts
@@ -6,6 +6,7 @@ import {
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
+import { IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
@@ -247,7 +248,7 @@ export class QACertificationEventWorkspaceService {
 
     const record = await this.repository.findOneBy({
       locationId,
-      certificationEventHour: payload.certificationEventHour,
+      certificationEventHour: payload.certificationEventHour ?? IsNull(),
       certificationEventDate: payload.certificationEventDate,
       certificationEventCode: payload.certificationEventCode,
       componentRecordId,

--- a/src/rata-summary-workspace/rata-summary-checks.service.ts
+++ b/src/rata-summary-workspace/rata-summary-checks.service.ts
@@ -141,13 +141,13 @@ export class RataSummaryChecksService {
       summary.endDate,
     );
 
-    const referenceMethodCodeDataSet = await this.referenceMethodCodeRepository.find(
-      {
-        where: {
-          referenceMethodCode,
-        },
-      },
-    );
+    const referenceMethodCodeDataSet = referenceMethodCode
+      ? await this.referenceMethodCodeRepository.find({
+          where: {
+            referenceMethodCode,
+          },
+        })
+      : [];
 
     const parameterCodes = referenceMethodCodeDataSet.reduce((acc, ds) => {
       const paramCodes = ds.parameterCode.split(',');

--- a/src/rata-workspace/rata-workspace.service.ts
+++ b/src/rata-workspace/rata-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -157,7 +157,7 @@ export class RataWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepository.findOneBy({
         testSumId: testSumId,
-        rataFrequencyCode: payload.rataFrequencyCode,
+        rataFrequencyCode: payload.rataFrequencyCode ?? IsNull(),
       });
     }
 

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-checks.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-checks.service.ts
@@ -2,6 +2,7 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { IsNull } from 'typeorm';
 
 import {
   TestExtensionExemptionBaseDTO,
@@ -111,11 +112,11 @@ export class TestExtensionExemptionsChecksService {
 
       testExtExempts = await this.repository.findBy({
         locationId,
-        reportPeriodId,
-        monitoringSystemRecordId,
-        componentRecordId,
+        reportPeriodId: reportPeriodId ?? IsNull(),
+        monitoringSystemRecordId: monitoringSystemRecordId ?? IsNull(),
+        componentRecordId: componentRecordId ?? IsNull(),
         extensionOrExemptionCode,
-        fuelCode,
+        fuelCode: fuelCode ?? IsNull(),
       });
 
       if (testExtExempts.length > 0) {

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.service.ts
@@ -6,6 +6,7 @@ import {
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
+import { IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import { ComponentWorkspaceRepository } from '../component-workspace/component.repository';
@@ -111,11 +112,11 @@ export class TestExtensionExemptionsWorkspaceService {
 
     const record = await this.repository.findOneBy({
       locationId,
-      fuelCode: payload.fuelCode,
+      fuelCode: payload.fuelCode ?? IsNull(),
       extensionOrExemptionCode: payload.extensionOrExemptionCode,
-      reportPeriodId,
-      monitoringSystemRecordId,
-      componentRecordId,
+      reportPeriodId: reportPeriodId ?? IsNull(),
+      monitoringSystemRecordId: monitoringSystemRecordId ?? IsNull(),
+      componentRecordId: componentRecordId ?? IsNull(),
     });
 
     let importedTestExtensionExemption;

--- a/src/test-qualification-workspace/test-qualification-workspace.service.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -173,7 +173,7 @@ export class TestQualificationWorkspaceService {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
         testClaimCode: payload.testClaimCode,
-        highLoadPercentage: payload.highLoadPercentage,
+        highLoadPercentage: payload.highLoadPercentage ?? IsNull(),
       });
     }
 

--- a/src/test-summary-workspace/test-summary-checks.service.ts
+++ b/src/test-summary-workspace/test-summary-checks.service.ts
@@ -2,6 +2,7 @@ import { HttpStatus, Injectable } from '@nestjs/common';
 import { CheckCatalogService } from '@us-epa-camd/easey-common/check-catalog';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
+import { IsNull } from 'typeorm';
 
 const moment = require('moment');
 
@@ -1333,7 +1334,7 @@ export class TestSummaryChecksService {
       [TestTypeCodes.LINE.toString()].includes(summary.testTypeCode)
     ) {
       const option = await this.testResultCodeRepository.findOneBy({
-        testResultCode: summary.testResultCode,
+        testResultCode: summary.testResultCode ?? IsNull(),
       });
 
       if (option) {
@@ -1372,7 +1373,7 @@ export class TestSummaryChecksService {
       ].includes(summary.testTypeCode)
     ) {
       const option = await this.testResultCodeRepository.findOneBy({
-        testResultCode: summary.testResultCode,
+        testResultCode: summary.testResultCode ?? IsNull(),
       });
 
       if (option) {

--- a/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.service.ts
+++ b/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -176,12 +176,13 @@ export class TransmitterTransducerAccuracyWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepository.findOneBy({
         testSumId: testSumId,
-        lowLevelAccuracy: payload.lowLevelAccuracy,
-        lowLevelAccuracySpecCode: payload.lowLevelAccuracySpecCode,
-        midLevelAccuracy: payload.midLevelAccuracy,
-        midLevelAccuracySpecCode: payload.midLevelAccuracySpecCode,
-        highLevelAccuracy: payload.highLevelAccuracy,
-        highLevelAccuracySpecCode: payload.highLevelAccuracySpecCode,
+        lowLevelAccuracy: payload.lowLevelAccuracy ?? IsNull(),
+        lowLevelAccuracySpecCode: payload.lowLevelAccuracySpecCode ?? IsNull(),
+        midLevelAccuracy: payload.midLevelAccuracy ?? IsNull(),
+        midLevelAccuracySpecCode: payload.midLevelAccuracySpecCode ?? IsNull(),
+        highLevelAccuracy: payload.highLevelAccuracy ?? IsNull(),
+        highLevelAccuracySpecCode:
+          payload.highLevelAccuracySpecCode ?? IsNull(),
       });
     }
 

--- a/src/unit-default-test-workspace/unit-default-test-workspace.service.ts
+++ b/src/unit-default-test-workspace/unit-default-test-workspace.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { EaseyException } from '@us-epa-camd/easey-common/exceptions';
 import { Logger } from '@us-epa-camd/easey-common/logger';
 import { currentDateTime } from '@us-epa-camd/easey-common/utilities/functions';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -184,7 +184,7 @@ export class UnitDefaultTestWorkspaceService {
     if (isHistoricalRecord) {
       historicalRecord = await this.historicalRepo.findOneBy({
         testSumId: testSumId,
-        noxDefaultRate: payload.noxDefaultRate,
+        noxDefaultRate: payload.noxDefaultRate ?? IsNull(),
       });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,10 +2223,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@us-epa-camd/easey-common@17.4.0":
-  version "17.4.0"
-  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.0/a3de0d7745b292b29fea5aedf961a112e96f109a#a3de0d7745b292b29fea5aedf961a112e96f109a"
-  integrity sha512-KhhdkCArNIYGlgSDOqjx7x0hQm/GEPygJoKIBFWxJ9k7Llrwy2mt+DU4P6wp+LqfdJgfM+7sTzKnSNY4xIjPIQ==
+"@us-epa-camd/easey-common@17.4.1":
+  version "17.4.1"
+  resolved "https://npm.pkg.github.com/download/@US-EPA-CAMD/easey-common/17.4.1/f48111f38d5204b5d7d308a7dffc9c202f0e083e#f48111f38d5204b5d7d308a7dffc9c202f0e083e"
+  integrity sha512-rgU7sceWwUiavS4QDnE4ntLPQJzY8zjK1eT042QJH/UXcHYkE22LQQRW4toU+g4LTknFa3NvvjS3Az52B4vHAA==
   dependencies:
     "@golevelup/ts-jest" "^0.3.4"
     "@nestjs/axios" "0.0.3"


### PR DESCRIPTION
## Main Changes

- The `IsNull()` helper must be explicitly used for `null` values in TypeORM `find*` methods version ^0.3.0.