### PR TITLE
fix(6185): addressed potential null fields

### DIFF
--- a/src/protocol-gas-workspace/protocol-gas-checks.service.ts
+++ b/src/protocol-gas-workspace/protocol-gas-checks.service.ts
@@ -52,22 +52,26 @@ export class ProtocolGasChecksService {
 
     if (isImport) {
       testSumRecord = testSummary;
-      testSumRecord.system = await this.monitorSystemWorkspaceRepository.findOne(
-        {
-          where: {
-            monitoringSystemID: testSummary.monitoringSystemId,
-            locationId,
+      if (testSummary.monitoringSystemId) {
+        testSumRecord.system = await this.monitorSystemWorkspaceRepository.findOne(
+          {
+            where: {
+              monitoringSystemID: testSummary.monitoringSystemId,
+              locationId,
+            },
           },
-        },
-      );
-      testSumRecord.component = await this.componentWorkspaceRepository.findOne(
-        {
-          where: {
-            componentID: testSummary.componentId,
-            locationId,
+        );
+      }
+      if (testSummary.componentId) {
+        testSumRecord.component = await this.componentWorkspaceRepository.findOne(
+          {
+            where: {
+              componentID: testSummary.componentId,
+              locationId,
+            },
           },
-        },
-      );
+        );
+      }
     } else {
       testSumRecord = await this.testSummaryRepository.getTestSummaryById(
         testSumId,


### PR DESCRIPTION
## Main Changes

- Addressed two more fields that could be potentially null.
  - These changes were the initial ones that spurred the other TypeORM null checks, but they were dropped by mistake when switching to a branch to address the issue as a whole.