### PR TITLE
fix(6185): addressed return value changing from undefined to null

### DIFF
--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -123,9 +123,7 @@ export class QACertificationWorkspaceService {
             locationId,
             summary,
             userId,
-            qaSupprecords[idx] !== undefined
-              ? qaSupprecords[idx]?.testSumId
-              : null,
+            qaSupprecords[idx] ? qaSupprecords[idx].testSumId : null,
           );
 
           resolve(results);


### PR DESCRIPTION
## Changes

In the previous changes made in response to the TypeORM update, I overlooked one breaking change noted in the [release notes](https://github.com/typeorm/typeorm/releases/tag/0.3.0):
> findOne and QueryBuilder.getOne() now return null instead of undefined in the case if it didn't find anything in the database.
Logically it makes more sense to return null.

This means that all explicit comparisons against `undefined` should be changed to `null` (alternatively, since the method will return either a complex type or `null`, one can just check if it is falsy).