### PR TITLE
fix:locid to locId and update appe50-a duplicate check

### DIFF
--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil-checks.service.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil-checks.service.ts
@@ -80,7 +80,6 @@ export class AppEHeatInputFromOilChecksService {
   ) {
     let error: string = null;
     let appETestSummary = appETestRun.appECorrelationTestSummary;
-    let testSummary = appETestSummary.testSummary;
 
     if (
       dto.monitoringSystemId &&
@@ -89,7 +88,7 @@ export class AppEHeatInputFromOilChecksService {
     ) {
       const duplicate = await this.repo.findDuplicate(
         aehiOilId,
-        testSummary.id,
+        appETestSummary.id,
         appETestSummary.operatingLevelForRun,
         appETestRun.runNumber,
         dto.monitoringSystemId,

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
@@ -130,7 +130,7 @@ export class AppEHeatInputFromOilWorkspaceController {
       'Updates an Appendix E Heat Input from Oil record in the workspace',
   })
   async editAppEHeatInputFromOil(
-    @Param('locid') locationId: string,
+    @Param('locId') locationId: string,
     @Param('testSumId') testSumId: string,
     @Param('appECorrTestSumId') _aeCorrTestSumId: string,
     @Param('appECorrTestRunId') aeCorrTestRunId: string,


### PR DESCRIPTION
## Ticket
[User Can't Enter Appendix E Correlation Heat Input from Oil Data Records](https://github.com/US-EPA-CAMD/easey-ui/issues/6239)

## Changes

- Update APPE-50-A duplicate validation [Updated like APPE49-A, and APPE-51-A]
-  editAppEHeatInputFromOil's `locid` parameter changed to `locId`