### PR TITLE
Bug: Add QACERT-11-A QCE screen check #1450

### DIFF
--- a/src/dto/qa-certification-event.dto.ts
+++ b/src/dto/qa-certification-event.dto.ts
@@ -55,26 +55,26 @@ export class QACertificationEventBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOId.description,
   })
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
   @MatchesRegEx('^[A-Z0-9]{1,3}$', {
     message: (args: ValidationArguments) => {
       return `The value of [${args.value}] for [${args.property}] must be 1 to 3 characters and only consist of upper case letters, numbers for [${KEY}].`;
     },
   })
-  monitoringSystemId?: string;
+  monitoringSystemId: string;
 
   @ApiProperty({
     description: propertyMetadata.componentDTOComponentId.description,
   })
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
   @MatchesRegEx('^[A-Z0-9]{1,3}$', {
     message: (args: ValidationArguments) => {
       return `The value of [${args.value}] for [${args.property}] must be 1 to 3 characters and only consist of upper case letters, numbers for [${KEY}].`;
     },
   })
-  componentId?: string;
+  componentId: string;
 
   @IsString()
   @IsNotEmpty()
@@ -115,14 +115,14 @@ export class QACertificationEventBaseDTO {
   })
   certificationEventHour?: number;
 
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
   @IsValidCode(RequiredTestCode, {
     message: (args: ValidationArguments) => {
       return `The value of [${args.value}] for [${args.property}] is invalid for [${KEY}]`;
     },
   })
-  requiredTestCode?: string;
+  requiredTestCode: string;
 
   @IsOptional()
   @IsIsoFormat({

--- a/src/dto/test-extension-exemption.dto.ts
+++ b/src/dto/test-extension-exemption.dto.ts
@@ -92,26 +92,26 @@ export class TestExtensionExemptionBaseDTO {
   @ApiProperty({
     description: propertyMetadata.monitorSystemDTOId.description,
   })
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
   @MatchesRegEx('^[A-Z0-9]{1,3}$', {
     message: (args: ValidationArguments) => {
       return `The value of [${args.value}] for [${args.property}] must be 1 to 3 characters and only consist of upper case letters, numbers for [${KEY}].`;
     },
   })
-  monitoringSystemId?: string;
+  monitoringSystemId: string;
 
   @ApiProperty({
     description: propertyMetadata.componentDTOComponentId.description,
   })
-  @IsOptional()
+  @IsNotEmpty()
   @IsString()
   @MatchesRegEx('^[A-Z0-9]{1,3}$', {
     message: (args: ValidationArguments) => {
       return `The value of [${args.value}] for [${args.property}] must be 1 to 3 characters and only consist of upper case letters, numbers for [${KEY}].`;
     },
   })
-  componentId?: string;
+  componentId: string;
 
   @IsOptional()
   @IsInt()


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/5786

Changes
Fixed the bug for saving null values for monitoring system id, component id and required test code.
![Screenshot 2024-06-20 155728](https://github.com/US-EPA-CAMD/easey-qa-certification-api/assets/169717416/d4a5ae05-22a5-4dd4-a088-6ed56568ff01)
![Screenshot 2024-06-20 155919](https://github.com/US-EPA-CAMD/easey-qa-certification-api/assets/169717416/33cfd166-d363-4644-9f9f-a16dbc2823ba)
