### PR TITLE
fix:remove workspace api from swagger beta env

### DIFF
--- a/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
+++ b/src/air-emission-testing-workspace/air-emission-testing-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 import { AirEmissionTestingChecksService } from './air-emission-testing-checks.service';
 import { AirEmissionTestingWorkspaceService } from './air-emission-testing-workspace.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class AirEmissionTestingWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAirEmissionTestings(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -69,6 +71,7 @@ export class AirEmissionTestingWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAirEmissionsTesting(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -86,6 +89,7 @@ export class AirEmissionTestingWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: AirEmissionTestingRecordDTO,
     description: 'Creates a workspace Air Emission Testing record.',
@@ -113,6 +117,7 @@ export class AirEmissionTestingWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: AirEmissionTestingRecordDTO,
     description: 'Updates a workspace Air Emission Testing record',
@@ -142,6 +147,7 @@ export class AirEmissionTestingWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Air Emission Testing record',
   })

--- a/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.controller.ts
+++ b/src/app-e-correlation-test-run-workspace/app-e-correlation-test-run-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 import { AppECorrelationTestRunWorkspaceService } from './app-e-correlation-test-run-workspace.service';
 import { AppECorrelationTestRunChecksService } from './app-e-correlation-test-run-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class AppECorrelationTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppECorrelationTestRuns(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -71,6 +73,7 @@ export class AppECorrelationTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppECorrelationTestRun(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -89,6 +92,7 @@ export class AppECorrelationTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: AppECorrelationTestRunRecordDTO,
     description: 'Creates a workspace Appendix E Correlation Test Run record.',
@@ -120,6 +124,7 @@ export class AppECorrelationTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: AppECorrelationTestRunRecordDTO,
     description: 'Updates a workspace Appendix E Correlation Test Run record.',
@@ -151,6 +156,7 @@ export class AppECorrelationTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Appendix E Correlation Test Run record.',
   })

--- a/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.controller.ts
+++ b/src/app-e-correlation-test-summary-workspace/app-e-correlation-test-summary-workspace.controller.ts
@@ -22,6 +22,7 @@ import { RoleGuard, User } from '@us-epa-camd/easey-common/decorators';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { AppECorrelationTestSummaryChecksService } from './app-e-correlation-test-summary-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class AppendixETestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppECorrelations(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -69,6 +71,7 @@ export class AppendixETestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppECorrelation(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -86,6 +89,7 @@ export class AppendixETestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: AppECorrelationTestSummaryRecordDTO,
     description:
@@ -110,6 +114,7 @@ export class AppendixETestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: AppECorrelationTestSummaryRecordDTO,
     description: 'Updates a workspace Appendix E Test Summary record',
@@ -139,6 +144,7 @@ export class AppendixETestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description:
       'Deletes a workspace Appendix E Correlation Test Summary record',

--- a/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.controller.ts
+++ b/src/app-e-heat-input-from-gas-workspace/app-e-heat-input-from-gas-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
 import { AppEHeatInputFromGasWorkspaceService } from './app-e-heat-input-from-gas-workspace.service';
 import { AppEHeatInputFromGasChecksService } from './app-e-heat-input-from-gas-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppEHeatInputFromGases(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -70,6 +72,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getAppEHeatInputFromGas(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -89,6 +92,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: AppEHeatInputFromGasRecordDTO,
     description: 'Creates a workspace Appendix E Heat Input From Gas record.',
@@ -121,6 +125,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: AppEHeatInputFromGasRecordDTO,
     description: 'Updates a workspace Appendix E Heat Input From Gas record.',
@@ -153,6 +158,7 @@ export class AppEHeatInputFromGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Appendix E Correlation Test Run record.',
   })

--- a/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
+++ b/src/app-e-heat-input-from-oil-workspace/app-e-heat-input-from-oil.controller.ts
@@ -23,6 +23,7 @@ import {
 import { AppEHeatInputFromOilWorkspaceService } from './app-e-heat-input-from-oil.service';
 import { AppEHeatInputFromOilChecksService } from './app-e-heat-input-from-oil-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getAppEHeatInputFromOilRecords(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -72,6 +74,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getAppEHeatInputFromOilRecord(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -91,6 +94,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: AppEHeatInputFromOilRecordDTO,
     description:
@@ -124,6 +128,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: AppEHeatInputFromOilRecordDTO,
     description:
@@ -157,6 +162,7 @@ export class AppEHeatInputFromOilWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Appendix E Correlation Test Run record.',
   })

--- a/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
+++ b/src/calibration-injection-workspace/calibration-injection-workspace.controller.ts
@@ -21,6 +21,7 @@ import {
   CalibrationInjectionDTO,
 } from '../dto/calibration-injection.dto';
 import { CalibrationInjectionWorkspaceService } from './calibration-injection-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -43,6 +44,7 @@ export class CalibrationInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCalibrationInjections(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -64,6 +66,7 @@ export class CalibrationInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCalibrationInjection(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -81,6 +84,7 @@ export class CalibrationInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: CalibrationInjectionDTO,
     description: 'Creates a workspace Calibration Injection record.',
@@ -107,6 +111,7 @@ export class CalibrationInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: CalibrationInjectionDTO,
     description: 'Updates a workspace Calibration Injection record.',
@@ -135,6 +140,7 @@ export class CalibrationInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Calibration Injection record.',
   })

--- a/src/cycle-time-injection-workspace/cycle-time-injection-workspace.controller.ts
+++ b/src/cycle-time-injection-workspace/cycle-time-injection-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '../dto/cycle-time-injection.dto';
 import { CycleTimeInjectionChecksService } from './cycle-time-injection-workspace-checks.service';
 import { CycleTimeInjectionWorkspaceService } from './cycle-time-injection-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class CycleTimeInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCycleTimeInjections(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -69,6 +71,7 @@ export class CycleTimeInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCycleTimeInjection(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -87,6 +90,7 @@ export class CycleTimeInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: CycleTimeInjectionRecordDTO,
     description: 'Creates a Cycle Time Injection record in the workspace',
@@ -122,6 +126,7 @@ export class CycleTimeInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: CycleTimeInjectionRecordDTO,
     description: ' Updates a Cycle Time Injection record in the workspace',
@@ -158,6 +163,7 @@ export class CycleTimeInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Cycle Time Injection record',
   })

--- a/src/cycle-time-summary-workspace/cycle-time-summary-workspace.controller.ts
+++ b/src/cycle-time-summary-workspace/cycle-time-summary-workspace.controller.ts
@@ -21,6 +21,7 @@ import {
   CycleTimeSummaryDTO,
 } from '../dto/cycle-time-summary.dto';
 import { CycleTimeSummaryWorkspaceService } from './cycle-time-summary-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -43,6 +44,7 @@ export class CycleTimeSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCycleTimeSummaries(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -64,6 +66,7 @@ export class CycleTimeSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getCycleTimeSummary(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -81,6 +84,7 @@ export class CycleTimeSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: CycleTimeSummaryDTO,
     description: 'Creates a workspace Cycle Time Summary record.',
@@ -103,6 +107,7 @@ export class CycleTimeSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: CycleTimeSummaryDTO,
     description: 'Updates a workspace Cycle Time Summary record.',
@@ -131,6 +136,7 @@ export class CycleTimeSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Cycle Time Summary record.',
   })

--- a/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
+++ b/src/flow-rata-run-workspace/flow-rata-run-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '../dto/flow-rata-run.dto';
 import { FlowRataRunChecksService } from './flow-rata-run-checks.service';
 import { FlowRataRunWorkspaceService } from './flow-rata-run-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class FlowRataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowRataRuns(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -71,6 +73,7 @@ export class FlowRataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowRataRun(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -91,6 +94,7 @@ export class FlowRataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     isArray: false,
     type: FlowRataRunRecordDTO,
@@ -133,6 +137,7 @@ export class FlowRataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FlowRataRunRecordDTO,
     description: 'Updates a Flow Rata Run record in the workspace',
@@ -175,6 +180,7 @@ export class FlowRataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Flow Rata Run record from the workspace',
   })

--- a/src/flow-to-load-check-workspace/flow-to-load-check-workspace.controller.ts
+++ b/src/flow-to-load-check-workspace/flow-to-load-check-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
   FlowToLoadCheckRecordDTO,
 } from '../dto/flow-to-load-check.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -44,6 +45,7 @@ export class FlowToLoadCheckWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowToLoadChecks(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -65,6 +67,7 @@ export class FlowToLoadCheckWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowToLoadCheck(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -82,6 +85,7 @@ export class FlowToLoadCheckWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: FlowToLoadCheckRecordDTO,
     description: 'Creates a workspace Flow To Load Check record.',
@@ -104,6 +108,7 @@ export class FlowToLoadCheckWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FlowToLoadCheckDTO,
     description: 'Updates a workspace Flow To Load Check record',
@@ -133,6 +138,7 @@ export class FlowToLoadCheckWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Flow To Load Check record from the workspace',
   })

--- a/src/flow-to-load-reference-workspace/flow-to-load-reference-workspace.controller.ts
+++ b/src/flow-to-load-reference-workspace/flow-to-load-reference-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
   FlowToLoadReferenceDTO,
 } from '../dto/flow-to-load-reference.dto';
 import { FlowToLoadReferenceWorkspaceService } from './flow-to-load-reference-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -44,6 +45,7 @@ export class FlowToLoadReferenceWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowToLoadReferences(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -66,6 +68,7 @@ export class FlowToLoadReferenceWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFlowToLoadReference(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -83,6 +86,7 @@ export class FlowToLoadReferenceWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: FlowToLoadReferenceDTO,
     description: 'Creates a workspace Flow To Load Reference record.',
@@ -109,6 +113,7 @@ export class FlowToLoadReferenceWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FlowToLoadReferenceDTO,
     description: 'Updates a workspace Flow To Load Reference record',
@@ -137,6 +142,7 @@ export class FlowToLoadReferenceWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Flow To Load Reference record from the workspace',
   })

--- a/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
+++ b/src/fuel-flow-to-load-baseline-workspace/fuel-flow-to-load-baseline-workspace.controller.ts
@@ -21,6 +21,7 @@ import {
   FuelFlowToLoadBaselineDTO,
 } from '../dto/fuel-flow-to-load-baseline.dto';
 import { FuelFlowToLoadBaselineWorkspaceService } from './fuel-flow-to-load-baseline-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -45,6 +46,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowToLoadBaselines(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -67,6 +69,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowToLoadBaseline(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -84,6 +87,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: FuelFlowToLoadBaselineDTO,
     description: 'Creates a workspace Fuel Flow To Load Baseline record.',
@@ -110,6 +114,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FuelFlowToLoadBaselineDTO,
     description: 'Updates a workspace Fuel Flow To Load Baseline record.',
@@ -138,6 +143,7 @@ export class FuelFlowToLoadBaselineWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description:
       'Deletes a Fuel Flow To Load Baseline record from the workspace',

--- a/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
+++ b/src/fuel-flow-to-load-test-workspace/fuel-flow-to-load-test-workspace.controller.ts
@@ -21,6 +21,7 @@ import {
   FuelFlowToLoadTestRecordDTO,
 } from '../dto/fuel-flow-to-load-test.dto';
 import { FuelFlowToLoadTestWorkspaceService } from './fuel-flow-to-load-test-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -43,6 +44,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowToLoadTests(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -64,6 +66,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowToLoadTest(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -81,6 +84,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: FuelFlowToLoadTestRecordDTO,
     description: 'Creates a workspace Fuel Flow To Load Test record.',
@@ -107,6 +111,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FuelFlowToLoadTestRecordDTO,
     description: 'Updates a Fuel Flow To Load Test record from the workspace',
@@ -135,6 +140,7 @@ export class FuelFlowToLoadTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Fuel Flow To Load Test record from the workspace',
   })

--- a/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.controller.ts
+++ b/src/fuel-flowmeter-accuracy-workspace/fuel-flowmeter-accuracy-workspace.controller.ts
@@ -21,6 +21,7 @@ import {
   FuelFlowmeterAccuracyDTO,
 } from '../dto/fuel-flowmeter-accuracy.dto';
 import { FuelFlowmeterAccuracyWorkspaceService } from './fuel-flowmeter-accuracy-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -45,6 +46,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowmeterAccuracies(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -67,6 +69,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getFuelFlowmeterAccuracy(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -84,6 +87,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: FuelFlowmeterAccuracyDTO,
     description: 'Creates a workspace Fuel Flowmeter Accuracy record.',
@@ -110,6 +114,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: FuelFlowmeterAccuracyDTO,
     description: 'Updates a workspace Fuel FLowmeter Accuracy record',
@@ -138,6 +143,7 @@ export class FuelFlowmeterAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Fuel Flowmeter record from the workspace',
   })

--- a/src/hg-injection-workspace/hg-injection-workspace.controller.ts
+++ b/src/hg-injection-workspace/hg-injection-workspace.controller.ts
@@ -15,6 +15,7 @@ import {
   HgInjectionRecordDTO,
 } from '../dto/hg-injection.dto';
 import { HgInjectionWorkspaceService } from './hg-injection-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -37,6 +38,7 @@ export class HgInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getHgInjections(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -58,6 +60,7 @@ export class HgInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getHgInjection(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -76,6 +79,7 @@ export class HgInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: HgInjectionRecordDTO,
     description: 'Creates a workspace Hg Injection record.',
@@ -104,6 +108,7 @@ export class HgInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: HgInjectionRecordDTO,
     description: 'Updates a workspace Hg Injection record.',
@@ -128,6 +133,7 @@ export class HgInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace HG Injection record',
   })

--- a/src/hg-summary-workspace/hg-summary-workspace.controller.ts
+++ b/src/hg-summary-workspace/hg-summary-workspace.controller.ts
@@ -18,6 +18,7 @@ import { HgSummaryBaseDTO, HgSummaryDTO } from '../dto/hg-summary.dto';
 import { HgSummaryWorkspaceService } from './hg-summary-workspace.service';
 import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -39,6 +40,7 @@ export class HgSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getHgSummaries(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -60,6 +62,7 @@ export class HgSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getHgSummary(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -77,6 +80,7 @@ export class HgSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: HgSummaryDTO,
     description: 'Creates a workspace Hg Summary record.',
@@ -99,6 +103,7 @@ export class HgSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: HgSummaryDTO,
     description: 'Updates a workspace Hg Summary record.',
@@ -122,6 +127,7 @@ export class HgSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a workspace Hg Summary record.',
   })

--- a/src/linearity-injection-workspace/linearity-injection.controller.ts
+++ b/src/linearity-injection-workspace/linearity-injection.controller.ts
@@ -26,6 +26,7 @@ import {
 import { LinearityInjectionChecksService } from './linearity-injection-checks.service';
 
 import { LinearityInjectionWorkspaceService } from './linearity-injection.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -51,6 +52,7 @@ export class LinearityInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getInjections(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -72,6 +74,7 @@ export class LinearityInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getLinearityInjection(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -90,6 +93,7 @@ export class LinearityInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: LinearityInjectionRecordDTO,
     description: 'Creates a Linearity Injection record in the workspace',
@@ -119,6 +123,7 @@ export class LinearityInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: LinearityInjectionRecordDTO,
     description: 'Updates a Linearity Injection record in the workspace',
@@ -150,6 +155,7 @@ export class LinearityInjectionWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Linearity Injection record from the workspace',
   })

--- a/src/linearity-summary-workspace/linearity-summary.controller.ts
+++ b/src/linearity-summary-workspace/linearity-summary.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '../dto/linearity-summary.dto';
 import { LinearitySummaryChecksService } from './linearity-summary-checks.service';
 import { LinearitySummaryWorkspaceService } from './linearity-summary.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -50,6 +51,7 @@ export class LinearitySummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getSummariesByTestSumId(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -70,6 +72,7 @@ export class LinearitySummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getSummaryById(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -87,6 +90,7 @@ export class LinearitySummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: LinearitySummaryRecordDTO,
     description: 'Creates a Linearity Summary record in the workspace',
@@ -110,6 +114,7 @@ export class LinearitySummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: LinearitySummaryRecordDTO,
     description: 'Updates a Linearity Summary record in the workspace',
@@ -134,6 +139,7 @@ export class LinearitySummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Linearity Summary record from the workspace',
   })

--- a/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
+++ b/src/online-offline-calibration-workspace/online-offline-calibration.controller.ts
@@ -22,6 +22,7 @@ import {
   OnlineOfflineCalibrationRecordDTO,
 } from '../dto/online-offline-calibration.dto';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -46,6 +47,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getOnlineOfflineCalibrations(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -68,6 +70,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getOnlineOfflineCalibration(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -85,6 +88,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: OnlineOfflineCalibrationRecordDTO,
     description:
@@ -112,6 +116,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Delete a workspace Online Offline Calibration record',
   })
@@ -137,6 +142,7 @@ export class OnlineOfflineCalibrationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: OnlineOfflineCalibrationRecordDTO,
     description:

--- a/src/protocol-gas-workspace/protocol-gas.controller.ts
+++ b/src/protocol-gas-workspace/protocol-gas.controller.ts
@@ -24,6 +24,7 @@ import {
 import { ProtocolGasWorkspaceService } from './protocol-gas.service';
 import { ProtocolGasChecksService } from './protocol-gas-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class ProtocolGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getProtocolGases(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -69,6 +71,7 @@ export class ProtocolGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getProtocolGas(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -86,6 +89,7 @@ export class ProtocolGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: ProtocolGasRecordDTO,
     description: 'Creates a Protocol Gas record in the workspace',
@@ -115,6 +119,7 @@ export class ProtocolGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: ProtocolGasRecordDTO,
     description: 'Updates a Protocol Gas record in the workspace',
@@ -145,6 +150,7 @@ export class ProtocolGasWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Protocol Gas record from the workspace',
   })

--- a/src/qa-certification-event-workspace/qa-certification-event-workspace.controller.ts
+++ b/src/qa-certification-event-workspace/qa-certification-event-workspace.controller.ts
@@ -25,6 +25,7 @@ import {
 } from '../dto/qa-certification-event.dto';
 import { QACertificationEventChecksService } from './qa-certification-event-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -50,6 +51,7 @@ export class QACertificationEventWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getQACertEvents(
     @Param('locId') locationId: string,
   ): Promise<QACertificationEventDTO[]> {
@@ -70,6 +72,7 @@ export class QACertificationEventWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getQACertEvent(
     @Param('locId') locationId: string,
     @Param('id') id: string,
@@ -86,6 +89,7 @@ export class QACertificationEventWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: QACertificationEventBaseDTO,
     description: 'Create a QA Certification Event record in the workspace',
@@ -108,6 +112,7 @@ export class QACertificationEventWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: QACertificationEventBaseDTO,
     description: 'Updates a QA Certification Event record in the workspace',
@@ -131,6 +136,7 @@ export class QACertificationEventWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a QA Certification Event from the workspace',
   })

--- a/src/qa-certification-workspace/qa-certification.controller.ts
+++ b/src/qa-certification-workspace/qa-certification.controller.ts
@@ -32,6 +32,7 @@ import { LookupType } from '@us-epa-camd/easey-common/enums';
 import { MatsBulkFileDTO } from '../dto/mats-bulk-file.dto';
 import { ReviewAndSubmitMultipleParamsMatsDTO } from '../dto/review-and-submit-multiple-params-mats.dto';
 import { MatsBulkFilesReviewAndSubmitService } from './mats-bulk-files-review-and-submit.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -86,6 +87,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async export(
     @Query() params: QACertificationParamsDTO,
   ): Promise<QACertificationDTO> {
@@ -106,6 +108,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: QACertificationDTO,
     description:
@@ -156,6 +159,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async getFilteredCerts(
     @Query() dto: ReviewAndSubmitMultipleParamsDTO,
   ): Promise<CertEventReviewAndSubmitDTO[]> {
@@ -200,6 +204,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async getFilteredTestSums(
     @Query() dto: ReviewAndSubmitMultipleParamsDTO,
   ): Promise<ReviewAndSubmitTestSummaryDTO[]> {
@@ -244,6 +249,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async getFilteredTee(
     @Query() dto: ReviewAndSubmitMultipleParamsDTO,
   ): Promise<TeeReviewAndSubmitDTO[]> {
@@ -282,6 +288,7 @@ export class QACertificationWorkspaceController {
     },
     LookupType.Facility,
   )
+  @ApiExcludeEndpointByEnv()
   async getFilteredMatsBulkFile(
     @Query() dto: ReviewAndSubmitMultipleParamsMatsDTO,
   ): Promise<MatsBulkFileDTO[]> {

--- a/src/rata-run-workspace/rata-run-workspace.controller.ts
+++ b/src/rata-run-workspace/rata-run-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '../dto/rata-run.dto';
 import { RataRunChecksService } from './rata-run-checks.service';
 import { RataRunWorkspaceService } from './rata-run-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class RataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRataRuns(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -70,6 +72,7 @@ export class RataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRataRun(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -89,6 +92,7 @@ export class RataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     isArray: false,
     type: RataRunRecordDTO,
@@ -128,6 +132,7 @@ export class RataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Rata Run record from the workspace',
   })
@@ -151,6 +156,7 @@ export class RataRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: RataRunRecordDTO,
     description: 'Updates a Rata Run record in the workspace',

--- a/src/rata-summary-workspace/rata-summary-workspace.controller.ts
+++ b/src/rata-summary-workspace/rata-summary-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '../dto/rata-summary.dto';
 import { RataSummaryChecksService } from './rata-summary-checks.service';
 import { RataSummaryWorkspaceService } from './rata-summary-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -46,6 +47,7 @@ export class RataSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getRataSummaryes(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -68,6 +70,7 @@ export class RataSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getRataSummary(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -86,6 +89,7 @@ export class RataSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: RataSummaryRecordDTO,
     description: 'Creates a workspace Rata Summary record.',
@@ -122,6 +126,7 @@ export class RataSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: RataSummaryRecordDTO,
     description: 'Updates a Rata summary record in the workspace',
@@ -154,6 +159,7 @@ export class RataSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Rata summary record from the workspace',
   })

--- a/src/rata-traverse-workspace/rata-traverse-workspace.controller.ts
+++ b/src/rata-traverse-workspace/rata-traverse-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '../dto/rata-traverse.dto';
 import { RataTraverseChecksService } from './rata-traverse-checks.service';
 import { RataTraverseWorkspaceService } from './rata-traverse-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class RataTraverseWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRataTraverses(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -72,6 +74,7 @@ export class RataTraverseWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRataTraverse(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -93,6 +96,7 @@ export class RataTraverseWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: RataTraverseRecordDTO,
     description: 'Creates a workspace RATA Traverse record.',
@@ -135,6 +139,7 @@ export class RataTraverseWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: RataTraverseRecordDTO,
     description: 'Updates a RATA Traverse record in the workspace',
@@ -173,6 +178,7 @@ export class RataTraverseWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a RATA Traverse record from the workspace',
   })

--- a/src/rata-workspace/rata-workspace.controller.ts
+++ b/src/rata-workspace/rata-workspace.controller.ts
@@ -19,6 +19,7 @@ import { CurrentUser } from '@us-epa-camd/easey-common/interfaces';
 import { RataBaseDTO, RataRecordDTO } from '../dto/rata.dto';
 import { RataChecksService } from './rata-checks.service';
 import { RataWorkspaceService } from './rata-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -43,6 +44,7 @@ export class RataWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRatas(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -63,6 +65,7 @@ export class RataWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getRata(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -80,6 +83,7 @@ export class RataWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: RataRecordDTO,
     description: 'Creates a Rata record in the workspace',
@@ -103,6 +107,7 @@ export class RataWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: RataRecordDTO,
     description: 'Updates a Rata record in the workspace',
@@ -133,6 +138,7 @@ export class RataWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a RATA record from the workspace',
   })

--- a/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
+++ b/src/test-extension-exemptions-workspace/test-extension-exemptions-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '../dto/test-extension-exemption.dto';
 import { TestExtensionExemptionsChecksService } from './test-extension-exemptions-checks.service';
 import { TestExtensionExemptionsWorkspaceService } from './test-extension-exemptions-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class TestExtensionExemptionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestExtensionExemptions(
     @Param('locId') locationId: string,
   ): Promise<TestExtensionExemptionRecordDTO[]> {
@@ -67,6 +69,7 @@ export class TestExtensionExemptionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestExtensionExemption(
     @Param('locId') _locationId: string,
     @Param('id') id: string,
@@ -83,6 +86,7 @@ export class TestExtensionExemptionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: TestExtensionExemptionRecordDTO,
     description: 'Creates a Test Extension Exemption record in the workspace',
@@ -109,6 +113,7 @@ export class TestExtensionExemptionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: TestExtensionExemptionRecordDTO,
     description: 'Updates a Test Extension Exemption record in the workspace',
@@ -137,6 +142,7 @@ export class TestExtensionExemptionsWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Test Extension Exemption from the workspace',
   })

--- a/src/test-qualification-workspace/test-qualification-workspace.controller.ts
+++ b/src/test-qualification-workspace/test-qualification-workspace.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '../dto/test-qualification.dto';
 import { TestQualificationChecksService } from './test-qualification-checks.service';
 import { TestQualificationWorkspaceService } from './test-qualification-workspace.service';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -47,6 +48,7 @@ export class TestQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestQualifications(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -68,6 +70,7 @@ export class TestQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestQualification(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -85,6 +88,7 @@ export class TestQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: TestQualificationRecordDTO,
     description: 'Creates a workspace Test Qualification record.',
@@ -121,6 +125,7 @@ export class TestQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: TestQualificationRecordDTO,
     description: 'Updates a test qualification record in the workspace',
@@ -159,6 +164,7 @@ export class TestQualificationWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a test qualification record from the workspace',
   })

--- a/src/test-summary-workspace/test-summary.controller.ts
+++ b/src/test-summary-workspace/test-summary.controller.ts
@@ -29,6 +29,7 @@ import { TestSummaryParamsDTO } from '../dto/test-summary-params.dto';
 import { TestSummaryWorkspaceService } from './test-summary.service';
 import { TestSummaryChecksService } from './test-summary-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -59,6 +60,7 @@ export class TestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestSummaries(
     @Param('locId') locationId: string,
     @Query() params: TestSummaryParamsDTO,
@@ -85,6 +87,7 @@ export class TestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getTestSummary(
     @Param('locId') _locationId: string,
     @Param('id') id: string,
@@ -101,6 +104,7 @@ export class TestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: TestSummaryRecordDTO,
     description: 'Creates a Test Summary record in the workspace',
@@ -123,6 +127,7 @@ export class TestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: TestSummaryRecordDTO,
     description: 'Updates a Test Summary record in the workspace',
@@ -146,6 +151,7 @@ export class TestSummaryWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Test Summary record from the workspace',
   })

--- a/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.controller.ts
+++ b/src/transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '../dto/transmitter-transducer-accuracy.dto';
 import { TransmitterTransducerAccuracyWorkspaceService } from '../transmitter-transducer-accuracy-workspace/transmitter-transducer-accuracy.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -48,6 +49,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getTransmitterTransducerAccuracies(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -70,6 +72,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   getTransmitterTransducerAccuracy(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -87,6 +90,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: TransmitterTransducerAccuracyRecordDTO,
     description:
@@ -114,6 +118,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: TransmitterTransducerAccuracyRecordDTO,
     description: 'Updates a workspace Transmitter Transducer Accuracy record',
@@ -142,6 +147,7 @@ export class TransmitterTransducerAccuracyWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: TransmitterTransducerAccuracyRecordDTO,
     description: 'Deletes a workspace Transmitter Transducer Accuracy record',

--- a/src/unit-default-test-run-workspace/unit-default-test-run.controller.ts
+++ b/src/unit-default-test-run-workspace/unit-default-test-run.controller.ts
@@ -24,6 +24,7 @@ import {
 import { UnitDefaultTestRunWorkspaceService } from './unit-default-test-run.service';
 import { UnitDefaultTestRunChecksService } from './unit-default-test-run-checks.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -49,6 +50,7 @@ export class UnitDefaultTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getUnitDefaultTestRuns(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -71,6 +73,7 @@ export class UnitDefaultTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getUnitDefaultTestRun(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -89,6 +92,7 @@ export class UnitDefaultTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: UnitDefaultTestRunRecordDTO,
     description: 'Creates a workspace Unit Default Test Run record.',
@@ -124,6 +128,7 @@ export class UnitDefaultTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     type: UnitDefaultTestRunRecordDTO,
     description: 'Updates a workspace Unit Default Test Run record.',
@@ -160,6 +165,7 @@ export class UnitDefaultTestRunWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a Unit Default Test Run record from the workspace',
   })

--- a/src/unit-default-test-workspace/unit-default-test-workspace.controller.ts
+++ b/src/unit-default-test-workspace/unit-default-test-workspace.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '../dto/unit-default-test.dto';
 import { UnitDefaultTestWorkspaceService } from './unit-default-test-workspace.service';
 import { LookupType } from '@us-epa-camd/easey-common/enums';
+import { ApiExcludeEndpointByEnv } from '../utilities/swagger-decorator.const';
 
 @Controller()
 @ApiSecurity('APIKey')
@@ -45,6 +46,7 @@ export class UnitDefaultTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getUnitDefaultTests(
     @Param('locId') _locationId: string,
     @Param('testSumId') testSumId: string,
@@ -66,6 +68,7 @@ export class UnitDefaultTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   async getUnitDefaultTest(
     @Param('locId') _locationId: string,
     @Param('testSumId') _testSumId: string,
@@ -83,6 +86,7 @@ export class UnitDefaultTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiCreatedResponse({
     type: UnitDefaultTestRecordDTO,
     description: 'Creates a workspace Unit Default Test record.',
@@ -105,6 +109,7 @@ export class UnitDefaultTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     isArray: true,
     type: UnitDefaultTestRecordDTO,
@@ -134,6 +139,7 @@ export class UnitDefaultTestWorkspaceController {
     },
     LookupType.Location,
   )
+  @ApiExcludeEndpointByEnv()
   @ApiOkResponse({
     description: 'Deletes a unit default test record from the workspace',
   })

--- a/src/utilities/swagger-decorator.const.ts
+++ b/src/utilities/swagger-decorator.const.ts
@@ -1,0 +1,14 @@
+import { ApiExcludeEndpoint, ApiExcludeController } from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
+
+const env = getConfigValue('EASEY_QA_CERTIFICATION_API_ENV', 'local-dev');
+const disable = ['locv','development','testing'].includes(env) ? false : true;
+
+export function ApiExcludeControllerByEnv() {
+    return applyDecorators(ApiExcludeController(disable));
+}
+
+export function ApiExcludeEndpointByEnv() {
+    return applyDecorators(ApiExcludeEndpoint(disable));
+}

--- a/src/utilities/swagger-decorator.const.ts
+++ b/src/utilities/swagger-decorator.const.ts
@@ -3,7 +3,7 @@ import { applyDecorators } from '@nestjs/common';
 import { getConfigValue } from '@us-epa-camd/easey-common/utilities';
 
 const env = getConfigValue('EASEY_QA_CERTIFICATION_API_ENV', 'local-dev');
-const disable = ['locv','development','testing'].includes(env) ? false : true;
+const disable = ['local-dev','development','testing'].includes(env) ? false : true;
 
 export function ApiExcludeControllerByEnv() {
     return applyDecorators(ApiExcludeController(disable));


### PR DESCRIPTION
## Ticket
[Remove qa-certification-mgmt's workspace API from Swagger page](https://github.com/US-EPA-CAMD/easey-ui/issues/6461)

## Changes

- Create a decorator for exclude APIs end points from swagger page
- Apply created decorated in workspace APIs