### PR TITLE
fix/#6517 Unable to Import QA Test Data from Historical Data

### DIFF
--- a/src/dto/protocol-gas.dto.ts
+++ b/src/dto/protocol-gas.dto.ts
@@ -53,7 +53,7 @@ export class ProtocolGasBaseDTO {
   @IsValidCodes(
     GasComponentCode,
     (args: ValidationArguments): FindOneOptions<GasComponentCode> => {
-      let codes = args.value.split(',');
+      let codes = args.value.toString().split(',');
       return { where: { gasComponentCode: In(codes) } };
     },
     {


### PR DESCRIPTION
### **Related Tickets:**
- ticket [#6517](https://github.com/orgs/US-EPA-CAMD/projects/2/views/45?sliceBy%5Bvalue%5D=EvanSun220&pane=issue&itemId=91671886&issue=US-EPA-CAMD%7Ceasey-ui%7C6517)
### **Updates:**
- explicitly convert args.value to string in protocol-gas.DTO.findOneOptions() to avoid the reported error

