### PR TITLE
Prevent partial QA imports/certification

### DIFF
--- a/src/qa-certification-workspace/qa-certification.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification.service.spec.ts
@@ -59,7 +59,7 @@ const airEmissionTesting = new AirEmissionTestingDTO();
 const qaCertEventDto = new QACertificationEventDTO();
 const qaCertDto = new QACertificationDTO();
 const testExtExmtDto = new TestExtensionExemptionDTO();
-qaCertDto.testSummaryData = [testSummary];
+qaCertDto.testSummaryData = [testSummary];//
 testSummary.calibrationInjectionData = [calibrationInjection];
 testSummary.linearitySummaryData = [linearitySummary];
 testSummary.rataData = [rata];
@@ -128,6 +128,40 @@ describe('QA Certification Workspace Service Test', () => {
   let service: QACertificationWorkspaceService;
   let entityManager: EntityManager;
 
+  // Helper for export test assertions
+  const assertExportResult = (result: any, expected: any): void => {
+    expect(result.orisCode).toEqual(expected.orisCode);
+    expect(result.testSummaryData).toEqual(expected.testSummaryData);
+    expect(result.certificationEventData).toEqual(expected.certificationEventData);
+    expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+  };
+
+  // Helper for creating export params
+  const createExportParams = (options: {
+    reportedValuesOnly?: boolean;
+    testSummaryIds?: string[];
+    qaCertificationEventIds?: string[];
+    qaTestExtensionExemptionIds?: string[];
+  } = {}): QACertificationParamsDTO => {
+    const paramsDTO = new QACertificationParamsDTO();
+    paramsDTO.facilityId = 1;
+    paramsDTO.reportedValuesOnly = options.reportedValuesOnly ?? false;
+
+    if (options.testSummaryIds) paramsDTO.testSummaryIds = options.testSummaryIds;
+    if (options.qaCertificationEventIds) paramsDTO.qaCertificationEventIds = options.qaCertificationEventIds;
+    if (options.qaTestExtensionExemptionIds) paramsDTO.qaTestExtensionExemptionIds = options.qaTestExtensionExemptionIds;
+
+    return paramsDTO;
+  };
+
+  // Helper for import test assertions
+  const assertImportResult = (result: any, orisCode: number): void => {
+    expect(result).toEqual({
+      message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${orisCode}]`,
+    });
+    expect(entityManager.transaction).toHaveBeenCalled();
+  };
+
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       imports: [LoggerModule],
@@ -172,13 +206,8 @@ describe('QA Certification Workspace Service Test', () => {
       expected.testExtensionExemptionData = [testExtExmtDto];
       expected.orisCode = 1;
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.reportedValuesOnly = true;
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
+      const paramsDTO = createExportParams({ reportedValuesOnly: true });
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
       expect(result).toEqual(expected);
     });
@@ -192,20 +221,10 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.testSummaryIds = ['1'];
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams({ testSummaryIds: ['1'] });
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
-
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('successfully calls export() with only qaCertificationEventIds', async () => {
@@ -217,20 +236,10 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.qaCertificationEventIds = ['1'];
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams({ qaCertificationEventIds: ['1'] });
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
-
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('successfully calls export() with only qaTestExtensionExemptionIds', async () => {
@@ -242,20 +251,10 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [testExtExmtDto],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.qaTestExtensionExemptionIds = ['1'];
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams({ qaTestExtensionExemptionIds: ['1'] });
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
-
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('successfully calls export() with all ID parameters defined', async () => {
@@ -267,22 +266,15 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [testExtExmtDto],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.testSummaryIds = ['1'];
-      paramsDTO.qaCertificationEventIds = ['1'];
-      paramsDTO.qaTestExtensionExemptionIds = ['1'];
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams({
+        testSummaryIds: ['1'],
+        qaCertificationEventIds: ['1'],
+        qaTestExtensionExemptionIds: ['1'],
+      });
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('successfully calls export() with mixed ID parameters', async () => {
@@ -294,22 +286,15 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.testSummaryIds = ['1'];
-      paramsDTO.qaCertificationEventIds = ['1'];
-      // No qaTestExtensionExemptionIds
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams({
+        testSummaryIds: ['1'],
+        qaCertificationEventIds: ['1'],
+        // No qaTestExtensionExemptionIds
+      });
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('handles undefined QaCertificationSchema', async () => {
@@ -324,23 +309,13 @@ describe('QA Certification Workspace Service Test', () => {
         testExtensionExemptionData: [testExtExmtDto],
       };
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.reportedValuesOnly = false;
-
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
+      const paramsDTO = createExportParams();
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
       // Restore original value
       service['easeyContentService'].QaCertificationSchema = originalSchema;
 
-      // Check that the result has the expected properties
-      expect(result.orisCode).toEqual(expected.orisCode);
-      expect(result.testSummaryData).toEqual(expected.testSummaryData);
-      expect(result.certificationEventData).toEqual(expected.certificationEventData);
-      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+      assertExportResult(result, expected);
     });
 
     it('successfully calls export() with rptValuesOnly = false', async () => {
@@ -350,9 +325,7 @@ describe('QA Certification Workspace Service Test', () => {
       expected.testExtensionExemptionData = [testExtExmtDto];
       expected.orisCode = 1;
 
-      const paramsDTO = new QACertificationParamsDTO();
-      paramsDTO.facilityId = 1;
-      paramsDTO.reportedValuesOnly = false;
+      const paramsDTO = createExportParams();
 
       // Mock removeNonReportedValues to verify it's not called
       const removeNonReportedValuesSpy = jest.spyOn(
@@ -360,10 +333,7 @@ describe('QA Certification Workspace Service Test', () => {
         'removeNonReportedValues',
       ).mockImplementation(jest.fn());
 
-      const result = await service.export(
-        paramsDTO,
-        paramsDTO.reportedValuesOnly,
-      );
+      const result = await service.export(paramsDTO, paramsDTO.reportedValuesOnly);
 
       expect(result.orisCode).toEqual(expected.orisCode);
       expect(removeNonReportedValuesSpy).not.toHaveBeenCalled();
@@ -373,20 +343,14 @@ describe('QA Certification Workspace Service Test', () => {
   describe('import', () => {
     it('successfully calls import() service function', async () => {
       const result = await service.import([location], payload, userId, []);
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
-      });
-      expect(entityManager.transaction).toHaveBeenCalled();
+      assertImportResult(result, payload.orisCode);
     });
 
     it('successfully calls import() service function when qaSuppData found ', async () => {
       const result = await service.import([location], payload, userId, [
         qaSuppData,
       ]);
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
-      });
-      expect(entityManager.transaction).toHaveBeenCalled();
+      assertImportResult(result, payload.orisCode);
     });
 
     it('handles errors and rolls back transaction', async () => {
@@ -421,10 +385,7 @@ describe('QA Certification Workspace Service Test', () => {
 
       const result = await service.import([location], emptyPayload, userId, []);
 
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${emptyPayload.orisCode}]`,
-      });
-      expect(entityManager.transaction).toHaveBeenCalled();
+      assertImportResult(result, emptyPayload.orisCode);
     });
 
     it('handles undefined arrays in payload', async () => {
@@ -434,10 +395,7 @@ describe('QA Certification Workspace Service Test', () => {
 
       const result = await service.import([location], undefinedPayload, userId, []);
 
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${undefinedPayload.orisCode}]`,
-      });
-      expect(entityManager.transaction).toHaveBeenCalled();
+      assertImportResult(result, undefinedPayload.orisCode);
     });
 
     it('handles partial payload with only testSummaryData', async () => {
@@ -452,11 +410,8 @@ describe('QA Certification Workspace Service Test', () => {
 
       const result = await service.import([location], partialPayload, userId, []);
 
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
-      });
+      assertImportResult(result, partialPayload.orisCode);
       expect(testSummaryServiceSpy).toHaveBeenCalled();
-      expect(entityManager.transaction).toHaveBeenCalled();
     });
 
     it('handles partial payload with only testExtensionExemptionData', async () => {
@@ -471,11 +426,8 @@ describe('QA Certification Workspace Service Test', () => {
 
       const result = await service.import([location], partialPayload, userId, []);
 
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
-      });
+      assertImportResult(result, partialPayload.orisCode);
       expect(testExtensionExemptionServiceSpy).toHaveBeenCalled();
-      expect(entityManager.transaction).toHaveBeenCalled();
     });
 
     it('handles partial payload with only certificationEventData', async () => {
@@ -490,13 +442,9 @@ describe('QA Certification Workspace Service Test', () => {
 
       const result = await service.import([location], partialPayload, userId, []);
 
-      expect(result).toEqual({
-        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
-      });
+      assertImportResult(result, partialPayload.orisCode);
       expect(qaCertEventServiceSpy).toHaveBeenCalled();
-      expect(entityManager.transaction).toHaveBeenCalled();
     });
   });
 });
-
 

--- a/src/qa-certification-workspace/qa-certification.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification.service.spec.ts
@@ -165,7 +165,7 @@ describe('QA Certification Workspace Service Test', () => {
   });
 
   describe('export', () => {
-    it('successfully calls export() service function', async () => {
+    it('successfully calls export() service function with all data', async () => {
       const expected = qaCertDto;
       expected.testSummaryData = [testSummary];
       expected.certificationEventData = [qaCertEventDto];
@@ -181,6 +181,192 @@ describe('QA Certification Workspace Service Test', () => {
       );
 
       expect(result).toEqual(expected);
+    });
+
+    it('successfully calls export() with only testSummaryIds', async () => {
+      const expected = {
+        version: undefined,
+        orisCode: 1,
+        testSummaryData: [testSummary],
+        certificationEventData: [],
+        testExtensionExemptionData: [],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.testSummaryIds = ['1'];
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('successfully calls export() with only qaCertificationEventIds', async () => {
+      const expected = {
+        version: undefined,
+        orisCode: 1,
+        testSummaryData: [],
+        certificationEventData: [qaCertEventDto],
+        testExtensionExemptionData: [],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.qaCertificationEventIds = ['1'];
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('successfully calls export() with only qaTestExtensionExemptionIds', async () => {
+      const expected = {
+        version: undefined,
+        orisCode: 1,
+        testSummaryData: [],
+        certificationEventData: [],
+        testExtensionExemptionData: [testExtExmtDto],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.qaTestExtensionExemptionIds = ['1'];
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('successfully calls export() with all ID parameters defined', async () => {
+      const expected = {
+        version: undefined,
+        orisCode: 1,
+        testSummaryData: [testSummary],
+        certificationEventData: [qaCertEventDto],
+        testExtensionExemptionData: [testExtExmtDto],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.testSummaryIds = ['1'];
+      paramsDTO.qaCertificationEventIds = ['1'];
+      paramsDTO.qaTestExtensionExemptionIds = ['1'];
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('successfully calls export() with mixed ID parameters', async () => {
+      const expected = {
+        version: undefined,
+        orisCode: 1,
+        testSummaryData: [testSummary],
+        certificationEventData: [qaCertEventDto],
+        testExtensionExemptionData: [],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.testSummaryIds = ['1'];
+      paramsDTO.qaCertificationEventIds = ['1'];
+      // No qaTestExtensionExemptionIds
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('handles undefined QaCertificationSchema', async () => {
+      // Temporarily set QaCertificationSchema to undefined
+      const originalSchema = service['easeyContentService'].QaCertificationSchema;
+      service['easeyContentService'].QaCertificationSchema = undefined;
+
+      const expected = {
+        orisCode: 1,
+        testSummaryData: [testSummary],
+        certificationEventData: [qaCertEventDto],
+        testExtensionExemptionData: [testExtExmtDto],
+      };
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.reportedValuesOnly = false;
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      // Restore original value
+      service['easeyContentService'].QaCertificationSchema = originalSchema;
+
+      // Check that the result has the expected properties
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(result.testSummaryData).toEqual(expected.testSummaryData);
+      expect(result.certificationEventData).toEqual(expected.certificationEventData);
+      expect(result.testExtensionExemptionData).toEqual(expected.testExtensionExemptionData);
+    });
+
+    it('successfully calls export() with rptValuesOnly = false', async () => {
+      const expected = qaCertDto;
+      expected.testSummaryData = [testSummary];
+      expected.certificationEventData = [qaCertEventDto];
+      expected.testExtensionExemptionData = [testExtExmtDto];
+      expected.orisCode = 1;
+
+      const paramsDTO = new QACertificationParamsDTO();
+      paramsDTO.facilityId = 1;
+      paramsDTO.reportedValuesOnly = false;
+
+      // Mock removeNonReportedValues to verify it's not called
+      const removeNonReportedValuesSpy = jest.spyOn(
+        require('../utilities/remove-non-reported-values'),
+        'removeNonReportedValues',
+      ).mockImplementation(jest.fn());
+
+      const result = await service.export(
+        paramsDTO,
+        paramsDTO.reportedValuesOnly,
+      );
+
+      expect(result.orisCode).toEqual(expected.orisCode);
+      expect(removeNonReportedValuesSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -225,5 +411,92 @@ describe('QA Certification Workspace Service Test', () => {
       // Verify transaction was called
       expect(entityManager.transaction).toHaveBeenCalled();
     });
+
+    it('handles empty arrays in payload', async () => {
+      const emptyPayload = new QACertificationImportDTO();
+      emptyPayload.orisCode = 1;
+      emptyPayload.testSummaryData = [];
+      emptyPayload.testExtensionExemptionData = [];
+      emptyPayload.certificationEventData = [];
+
+      const result = await service.import([location], emptyPayload, userId, []);
+
+      expect(result).toEqual({
+        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${emptyPayload.orisCode}]`,
+      });
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('handles undefined arrays in payload', async () => {
+      const undefinedPayload = new QACertificationImportDTO();
+      undefinedPayload.orisCode = 1;
+      // No arrays defined
+
+      const result = await service.import([location], undefinedPayload, userId, []);
+
+      expect(result).toEqual({
+        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${undefinedPayload.orisCode}]`,
+      });
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('handles partial payload with only testSummaryData', async () => {
+      const partialPayload = new QACertificationImportDTO();
+      partialPayload.orisCode = 1;
+      partialPayload.testSummaryData = [new TestSummaryImportDTO()];
+      partialPayload.testSummaryData[0].unitId = '1';
+      partialPayload.testSummaryData[0].stackPipeId = '1';
+      // No other data types
+
+      const testSummaryServiceSpy = jest.spyOn(service['testSummaryService'], 'import');
+
+      const result = await service.import([location], partialPayload, userId, []);
+
+      expect(result).toEqual({
+        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
+      });
+      expect(testSummaryServiceSpy).toHaveBeenCalled();
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('handles partial payload with only testExtensionExemptionData', async () => {
+      const partialPayload = new QACertificationImportDTO();
+      partialPayload.orisCode = 1;
+      partialPayload.testExtensionExemptionData = [new TestExtensionExemptionImportDTO()];
+      partialPayload.testExtensionExemptionData[0].unitId = '1';
+      partialPayload.testExtensionExemptionData[0].stackPipeId = '1';
+      // No other data types
+
+      const testExtensionExemptionServiceSpy = jest.spyOn(service['testExtensionExemptionService'], 'import');
+
+      const result = await service.import([location], partialPayload, userId, []);
+
+      expect(result).toEqual({
+        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
+      });
+      expect(testExtensionExemptionServiceSpy).toHaveBeenCalled();
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('handles partial payload with only certificationEventData', async () => {
+      const partialPayload = new QACertificationImportDTO();
+      partialPayload.orisCode = 1;
+      partialPayload.certificationEventData = [new QACertificationEventImportDTO()];
+      partialPayload.certificationEventData[0].unitId = '1';
+      partialPayload.certificationEventData[0].stackPipeId = '1';
+      // No other data types
+
+      const qaCertEventServiceSpy = jest.spyOn(service['qaCertEventService'], 'import');
+
+      const result = await service.import([location], partialPayload, userId, []);
+
+      expect(result).toEqual({
+        message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${partialPayload.orisCode}]`,
+      });
+      expect(qaCertEventServiceSpy).toHaveBeenCalled();
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
   });
 });
+
+

--- a/src/qa-certification-workspace/qa-certification.service.spec.ts
+++ b/src/qa-certification-workspace/qa-certification.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { EntityManager } from 'typeorm';
 import {
   QACertificationDTO,
   QACertificationImportDTO,
@@ -117,8 +118,15 @@ const mockQATestExtensionExemptionService = () => ({
   import: jest.fn().mockResolvedValue(undefined),
 });
 
+const mockEntityManager = () => ({
+  transaction: jest.fn().mockImplementation(async callback => {
+    return await callback();
+  }),
+});
+
 describe('QA Certification Workspace Service Test', () => {
   let service: QACertificationWorkspaceService;
+  let entityManager: EntityManager;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -145,10 +153,15 @@ describe('QA Certification Workspace Service Test', () => {
             }),
           })
         },
+        {
+          provide: EntityManager,
+          useFactory: mockEntityManager,
+        },
       ],
     }).compile();
 
     service = module.get(QACertificationWorkspaceService);
+    entityManager = module.get(EntityManager);
   });
 
   describe('export', () => {
@@ -177,6 +190,7 @@ describe('QA Certification Workspace Service Test', () => {
       expect(result).toEqual({
         message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
       });
+      expect(entityManager.transaction).toHaveBeenCalled();
     });
 
     it('successfully calls import() service function when qaSuppData found ', async () => {
@@ -186,6 +200,30 @@ describe('QA Certification Workspace Service Test', () => {
       expect(result).toEqual({
         message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
       });
+      expect(entityManager.transaction).toHaveBeenCalled();
+    });
+
+    it('handles errors and rolls back transaction', async () => {
+      // Mock the transaction method to simulate error handling
+      jest.spyOn(entityManager, 'transaction').mockImplementation(async (callback: any) => {
+        try {
+          return await callback();
+        } catch (error) {
+          throw error;
+        }
+      });
+
+      // Mock the testSummaryService to throw an error
+      const testSummaryService = jest.spyOn(service['testSummaryService'], 'import');
+      testSummaryService.mockRejectedValueOnce(new Error('Test error'));
+
+      // Expect the import to throw an error
+      await expect(
+        service.import([location], payload, userId, []),
+      ).rejects.toThrow('Test error');
+
+      // Verify transaction was called
+      expect(entityManager.transaction).toHaveBeenCalled();
     });
   });
 });

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -201,7 +201,7 @@ export class QACertificationWorkspaceService {
         this.logger.error(
           `Error in QA Certification import transaction for Facility Id/Oris Code [${payload.orisCode}]: ${error.message}`,
         );
-        throw error; // Transaction will automatically roll back
+        throw error; // Transaction will automatically roll back if there any error
       }
     });
   }

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 
 import { Logger } from '@us-epa-camd/easey-common/logger';
 
@@ -19,6 +21,8 @@ import { EaseyContentService } from '../qa-certification-easey-content/easey-con
 @Injectable()
 export class QACertificationWorkspaceService {
   constructor(
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
     private readonly logger: Logger,
     private readonly testSummaryService: TestSummaryWorkspaceService,
     private readonly testExtensionExemptionService: TestExtensionExemptionsWorkspaceService,
@@ -112,75 +116,93 @@ export class QACertificationWorkspaceService {
       `Importing QA Certification data for Facility Id/Oris Code [${payload.orisCode}]`,
     );
 
-    const promises = [];
-    payload.testSummaryData?.forEach((summary, idx) => {
-      promises.push(
-        new Promise((resolve, _reject) => {
-          const locationId = locations.find(i => {
-            return (
-              i.unitId === summary.unitId &&
-              i.stackPipeId === summary.stackPipeId
-            );
-          }).locationId;
-
-          const results = this.testSummaryService.import(
-            locationId,
-            summary,
-            userId,
-            qaSupprecords[idx] ? qaSupprecords[idx].testSumId : null,
-          );
-
-          resolve(results);
-        }),
-      );
-    });
-
-    payload.testExtensionExemptionData?.forEach(
-      (qaTestExtensionExemptionId, idx) => {
-        promises.push(
-          new Promise((resolve, _reject) => {
-            const locationId = locations.find(i => {
-              return (
-                i.unitId === qaTestExtensionExemptionId.unitId &&
-                i.stackPipeId === qaTestExtensionExemptionId.stackPipeId
-              );
-            }).locationId;
-
-            const results = this.testExtensionExemptionService.import(
-              locationId,
-              qaTestExtensionExemptionId,
-              userId,
-            );
-            resolve(results);
-          }),
+    // Use transaction to ensure atomic operations
+    return await this.entityManager.transaction(async () => {
+      try {
+        this.logger.log(
+          `Starting QA Certification import transaction for Facility Id/Oris Code [${payload.orisCode}]`,
         );
-      },
-    );
-    payload.certificationEventData?.forEach((qaCertEvent, idx) => {
-      promises.push(
-        new Promise((resolve, _reject) => {
-          const locationId = locations.find(i => {
-            return (
-              i.unitId === qaCertEvent.unitId &&
-              i.stackPipeId === qaCertEvent.stackPipeId
-            );
-          }).locationId;
 
-          const results = this.qaCertEventService.import(
-            locationId,
-            qaCertEvent,
-            userId,
+        const promises = [];
+        payload.testSummaryData?.forEach((summary, idx) => {
+          promises.push(
+            new Promise((resolve, _reject) => {
+              const locationId = locations.find(i => {
+                return (
+                  i.unitId === summary.unitId &&
+                  i.stackPipeId === summary.stackPipeId
+                );
+              }).locationId;
+
+              const results = this.testSummaryService.import(
+                locationId,
+                summary,
+                userId,
+                qaSupprecords[idx] ? qaSupprecords[idx].testSumId : null,
+              );
+
+              resolve(results);
+            }),
           );
+        });
 
-          resolve(results);
-        }),
-      );
+        payload.testExtensionExemptionData?.forEach(
+          (qaTestExtensionExemptionId, idx) => {
+            promises.push(
+              new Promise((resolve, _reject) => {
+                const locationId = locations.find(i => {
+                  return (
+                    i.unitId === qaTestExtensionExemptionId.unitId &&
+                    i.stackPipeId === qaTestExtensionExemptionId.stackPipeId
+                  );
+                }).locationId;
+
+                const results = this.testExtensionExemptionService.import(
+                  locationId,
+                  qaTestExtensionExemptionId,
+                  userId,
+                );
+                resolve(results);
+              }),
+            );
+          },
+        );
+        payload.certificationEventData?.forEach((qaCertEvent, idx) => {
+          promises.push(
+            new Promise((resolve, _reject) => {
+              const locationId = locations.find(i => {
+                return (
+                  i.unitId === qaCertEvent.unitId &&
+                  i.stackPipeId === qaCertEvent.stackPipeId
+                );
+              }).locationId;
+
+              const results = this.qaCertEventService.import(
+                locationId,
+                qaCertEvent,
+                userId,
+              );
+
+              resolve(results);
+            }),
+          );
+        });
+
+        await Promise.all(promises);
+
+        this.logger.log(
+          `Successfully completed QA Certification import transaction for Facility Id/Oris Code [${payload.orisCode}]`,
+        );
+
+        return {
+          message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
+        };
+      } catch (error) {
+        this.logger.error(
+          `Error in QA Certification import transaction for Facility Id/Oris Code [${payload.orisCode}]: ${error.message}`,
+        );
+        throw error; // Transaction will automatically roll back
+      }
     });
-
-    await Promise.all(promises);
-
-    return {
-      message: `Successfully Imported QA Certification Data for Facility Id/Oris Code [${payload.orisCode}]`,
-    };
   }
 }

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -201,7 +201,7 @@ export class QACertificationWorkspaceService {
         this.logger.error(
           `Error in QA Certification import transaction for Facility Id/Oris Code [${payload.orisCode}]: ${error.message}`,
         );
-        throw error; // Transaction will automatically roll back if there any error
+        throw error; // Transaction will automatically roll back if there is any error
       }
     });
   }


### PR DESCRIPTION
### Changes made:
Implement transaction handling for QA imports to prevent partial imports by:
- Adding transaction support to QA certification import process
- Wrapped import operations in single database transaction
- Ensured atomic operations with complete rollback on error
- Added enhanced logging for transaction tracking
- Updated tests to verify transaction behavior




