### PR TITLE
Fix/6513 mats forbidden resource error

### DIFF
--- a/src/mats-data-submission/mats-data-submission-root.controller.ts
+++ b/src/mats-data-submission/mats-data-submission-root.controller.ts
@@ -33,6 +33,7 @@ export class MatsDataSubmissionRootController {
     {
       queryParam: 'monPlanIds',
       isPipeDelimitted: true,
+      enforceCheckout: false,
       enforceEvalSubmitCheck: false,
     },
     LookupType.MonitorPlan,


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6513
- https://github.com/US-EPA-CAMD/easey-ui/issues/6110

## Main Changes:

- Don't require that a configuration is checked out when simply getting a list of MATS submissions (the default of `enforceCheckout` is "true").