### PR TITLE
fix/#6787 Issues When QAT is Deleted

### DIFF
--- a/src/test-summary-workspace/test-summary.service.spec.ts
+++ b/src/test-summary-workspace/test-summary.service.spec.ts
@@ -58,6 +58,7 @@ import { TestSummaryWorkspaceRepository } from './test-summary.repository';
 import { TestSummaryWorkspaceService } from './test-summary.service';
 import { ReviewAndSubmitTestSummaryDTO } from '../dto/review-and-submit-test-summary.dto';
 import { TestSummaryReviewAndSubmitService } from '../qa-certification-workspace/test-summary-review-and-submit.service';
+import { EntityManager } from 'typeorm';
 
 const locationId = '121';
 const facilityId = 1;
@@ -210,6 +211,7 @@ describe('TestSummaryWorkspaceService', () => {
   let locationRepository: MonitorLocationRepository;
   let monitorSystemRepository: MonitorSystemRepository;
   let monitorSystemWorkspaceRepository: MonitorSystemWorkspaceRepository;
+  let manager: EntityManager;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -332,6 +334,10 @@ describe('TestSummaryWorkspaceService', () => {
           provide: QASuppDataWorkspaceService,
           useFactory: mockQASuppDataWorkspaceService,
         },
+        {
+          provide: EntityManager,
+          useValue: { transaction: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -341,6 +347,7 @@ describe('TestSummaryWorkspaceService', () => {
     monitorSystemWorkspaceRepository = module.get(
       MonitorSystemWorkspaceRepository,
     );
+    manager = module.get(EntityManager);
   });
 
   describe('getTestSummaryById', () => {
@@ -457,13 +464,54 @@ describe('TestSummaryWorkspaceService', () => {
   });
 
   describe('deleteTestSummary', () => {
-    it('should call the deleteTestSummary and delete test summariy', async () => {
+    it('deletes a record and reverts QA supp data when an official record exists', async () => {
+      const transactionalEntityManager = { query: jest.fn() };
+      
+      (manager.transaction as jest.Mock).mockImplementation(async (callback) => {
+        await callback(transactionalEntityManager);
+      });
+
+      (transactionalEntityManager.query as jest.Mock).mockResolvedValue([ { '1': 1 } ]);
+
       const result = await service.deleteTestSummary(testSumId);
 
-      expect(result).toEqual(undefined);
+      expect(result).toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith(testSumId);
+      
+      // Verify the correct sequence of queries inside the transaction
+      const queryCalls = transactionalEntityManager.query.mock.calls;
+      expect(queryCalls.length).toBe(4);
+      expect(queryCalls[0][0]).toContain('DELETE FROM camdecmpswks.qa_supp_data');
+      expect(queryCalls[1][0]).toContain('SELECT 1 FROM camdecmps.qa_supp_data');
+      expect(queryCalls[2][0]).toContain('INSERT INTO camdecmpswks.qa_supp_data');
+      expect(queryCalls[3][0]).toContain('INSERT INTO camdecmpswks.qa_supp_attribute');
     });
 
-    it('should call the deleteTestSummary and throw error while deleting test summariy', async () => {
+    it('deletes a record and its QA supp data when no official record exists', async () => {
+      const transactionalEntityManager = { query: jest.fn() };
+      
+      (manager.transaction as jest.Mock).mockImplementation(async (callback) => {
+        await callback(transactionalEntityManager);
+      });
+
+      (transactionalEntityManager.query as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.deleteTestSummary(testSumId);
+
+      expect(result).toBeUndefined();
+      expect(repository.delete).toHaveBeenCalledWith(testSumId);
+
+      // Verify the correct sequence of queries inside the transaction
+      const queryCalls = transactionalEntityManager.query.mock.calls;
+      expect(queryCalls.length).toBe(2);
+      expect(queryCalls[0][0]).toContain('DELETE FROM camdecmpswks.qa_supp_data');
+      expect(queryCalls[1][0]).toContain('SELECT 1 FROM camdecmps.qa_supp_data');
+      expect(transactionalEntityManager.query).not.toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO'),
+      );
+    });
+
+    it('should throw an error while deleting test summary', async () => {
       jest
         .spyOn(repository, 'delete')
         .mockRejectedValue(new InternalServerErrorException());

--- a/src/test-summary-workspace/test-summary.service.ts
+++ b/src/test-summary-workspace/test-summary.service.ts
@@ -42,12 +42,14 @@ import { TransmitterTransducerAccuracyWorkspaceService } from '../transmitter-tr
 import { UnitDefaultTestWorkspaceService } from '../unit-default-test-workspace/unit-default-test-workspace.service';
 import { TestSummaryWorkspaceRepository } from './test-summary.repository';
 import { TestSummaryReviewAndSubmitService } from '../qa-certification-workspace/test-summary-review-and-submit.service';
+import { EntityManager } from 'typeorm';
 
 @Injectable()
 export class TestSummaryWorkspaceService {
   constructor(
     private readonly logger: Logger,
     private readonly map: TestSummaryMap,
+    private readonly manager: EntityManager,
     @Inject(forwardRef(() => TestSummaryReviewAndSubmitService))
     private readonly testSummaryReviewAndSubmitService: TestSummaryReviewAndSubmitService,
     @Inject(forwardRef(() => LinearitySummaryWorkspaceService))
@@ -781,7 +783,50 @@ export class TestSummaryWorkspaceService {
 
   async deleteTestSummary(id: string): Promise<void> {
     try {
+      // Delete camdecmpswks.test_summary record
       await this.repository.delete(id);
+
+      await this.manager.transaction(async (transactionalEntityManager) => {
+
+        // Delete the related record in camdecmpswks.qa_supp_data and the dependent table camdecmpswks.qa_supp_attribute
+        await transactionalEntityManager.query(
+          `DELETE FROM camdecmpswks.qa_supp_data WHERE test_sum_id = $1`,
+          [id],
+        );
+
+        // Check if the official record exist
+        const submittedRecord = await transactionalEntityManager.query(
+          `SELECT 1 FROM camdecmps.qa_supp_data WHERE test_sum_id = $1`,
+          [id],
+        );
+
+        if (submittedRecord.length > 0) {
+
+          // Revert the qa_supp_data record in the workspace table with the info from the official table 
+          await transactionalEntityManager.query(
+            `INSERT INTO camdecmpswks.qa_supp_data(
+		          qa_supp_data_id, mon_loc_id, mon_sys_id, component_id, test_type_cd, test_sum_id, test_reason_cd, test_num, span_scale, begin_date, begin_hour, begin_min, end_date, end_hour, end_min, rpt_period_id, test_result_cd, gp_ind, reinstallation_date, reinstallation_hour, test_expire_date, test_expire_hour, userid, add_date, update_date, op_level_cd, submission_id, submission_availability_cd, operating_condition_cd, fuel_cd
+	          )
+	          SELECT
+		          qa_supp_data_id, mon_loc_id, mon_sys_id, component_id, test_type_cd, test_sum_id, test_reason_cd, test_num, span_scale, begin_date, begin_hour, begin_min, end_date, end_hour, end_min, rpt_period_id, test_result_cd, gp_ind, reinstallation_date, reinstallation_hour, test_expire_date, test_expire_hour, userid, add_date, update_date, op_level_cd, submission_id, submission_availability_cd, operating_condition_cd, fuel_cd
+	          FROM camdecmps.qa_supp_data 
+            WHERE test_sum_id = $1`,
+            [id],
+          );
+          
+          // Revert the qa_supp_attribute record in the workspace table with the info from the official table 
+          await transactionalEntityManager.query(
+            `INSERT INTO camdecmpswks.qa_supp_attribute
+             SELECT * FROM camdecmps.qa_supp_attribute 
+             WHERE qa_supp_data_id IN (
+               SELECT qa_supp_data_id 
+               FROM camdecmps.qa_supp_data 
+               WHERE test_sum_id = $1
+             )`,
+            [id],
+          );
+        }
+      });
     } catch (e) {
       throw new InternalServerErrorException(
         `Error deleting Test Summary record Id [${id}]`,


### PR DESCRIPTION
## Related Ticket:

- ticket [#6787](https://github.com/US-EPA-CAMD/easey-ui/issues/6787)

## Updates:

- Updated the test-summary-service.deleteTestSummary to handle the request changes needed for deleting QA test records from the UI.
- Updated related tests.
