### PR TITLE
Fix/6971 typeorm floats

### DIFF
--- a/src/entities/analyzerRange.entity.ts
+++ b/src/entities/analyzerRange.entity.ts
@@ -33,6 +33,7 @@ export class AnalyzerRange extends BaseEntity {
   @Column({
     name: 'dual_range_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   dualRangeIndicator: number;
 
@@ -42,10 +43,18 @@ export class AnalyzerRange extends BaseEntity {
   @Column({ type: 'date', nullable: true, name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'begin_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'begin_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   beginHour: number;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endHour: number;
 
   @Column({
@@ -61,10 +70,7 @@ export class AnalyzerRange extends BaseEntity {
   @Column({ type: 'timestamp', name: 'update_date' })
   updateDate: Date;
 
-  @ManyToOne(
-    () => Component,
-    c => c.analyzerRanges,
-  )
+  @ManyToOne(() => Component, (c) => c.analyzerRanges)
   @JoinColumn({ name: 'component_id' })
   component: Component;
 }

--- a/src/entities/app-e-correlation-test-run.entity.ts
+++ b/src/entities/app-e-correlation-test-run.entity.ts
@@ -28,42 +28,49 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'run_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runNumber: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 
   @Column({
     name: 'hourly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   hourlyHeatInputRate: number;
 
   @Column({
     name: 'calc_hourly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedHourlyHeatInputRate: number;
 
   @Column({
     name: 'total_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   totalHeatInput: number;
 
   @Column({
     name: 'calc_total_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedTotalHeatInput: number;
 
   @Column({
     name: 'response_time',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   responseTime: number;
 
@@ -76,12 +83,14 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -94,12 +103,14 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 

--- a/src/entities/app-e-correlation-test-summary.entity.ts
+++ b/src/entities/app-e-correlation-test-summary.entity.ts
@@ -36,36 +36,42 @@ export class AppECorrelationTestSummary extends BaseEntity {
     name: 'op_level_num',
     nullable: false,
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   operatingLevelForRun: number;
 
   @Column({
     name: 'mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanReferenceValue: number;
 
   @Column({
     name: 'calc_mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'calc_avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageHourlyHeatInputRate: number;
 
   @Column({
     name: 'f_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   fFactor: number;
 

--- a/src/entities/app-e-heat-input-from-oil.entity.ts
+++ b/src/entities/app-e-heat-input-from-oil.entity.ts
@@ -35,30 +35,35 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_mass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilMass: number;
 
   @Column({
     name: 'calc_oil_mass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOilMass: number;
 
   @Column({
     name: 'oil_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilHeatInput: number;
 
   @Column({
     name: 'calc_oil_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOilHeatInput: number;
 
   @Column({
     name: 'oil_gcv',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilGCV: number;
 
@@ -70,6 +75,7 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_volume',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilVolume: number;
 
@@ -81,6 +87,7 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_density',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilDensity: number;
 

--- a/src/entities/calibration-injection.entity.ts
+++ b/src/entities/calibration-injection.entity.ts
@@ -29,36 +29,42 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'online_offline_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   onlineOfflineIndicator: number;
 
   @Column({
     name: 'zero_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroReferenceValue: number;
 
   @Column({
     name: 'zero_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroCalibrationError: number;
 
   @Column({
     name: 'calc_zero_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedZeroCalibrationError: number;
 
   @Column({
     name: 'zero_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroAPSIndicator: number;
 
   @Column({
     name: 'calc_zero_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedZeroAPSIndicator: number;
 
@@ -71,24 +77,28 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'zero_injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroInjectionHour: number;
 
   @Column({
     name: 'zero_injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroInjectionMinute: number;
 
   @Column({
     name: 'upscale_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleReferenceValue: number;
 
   @Column({
     name: 'zero_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroMeasuredValue: number;
 
@@ -101,30 +111,35 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'upscale_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleMeasuredValue: number;
 
   @Column({
     name: 'upscale_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleCalibrationError: number;
 
   @Column({
     name: 'calc_upscale_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedUpscaleCalibrationError: number;
 
   @Column({
     name: 'upscale_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleAPSIndicator: number;
 
   @Column({
     name: 'calc_upscale_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedUpscaleAPSIndicator: number;
 
@@ -137,12 +152,14 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'upscale_injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleInjectionHour: number;
 
   @Column({
     name: 'upscale_injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleInjectionMinute: number;
 

--- a/src/entities/cycle-time-summary.entity.ts
+++ b/src/entities/cycle-time-summary.entity.ts
@@ -31,12 +31,14 @@ export class CycleTimeSummary extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'total_time',
   })
   totalTime: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_total_time',
   })
   calculatedTotalTime: number;

--- a/src/entities/flow-rata-run.entity.ts
+++ b/src/entities/flow-rata-run.entity.ts
@@ -22,93 +22,119 @@ export class FlowRataRun extends BaseEntity {
   @Column({
     name: 'num_traverse_point',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfTraversePoints: number;
 
   @Column({
     name: 'barometric_pressure',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   barometricPressure: number;
 
   @Column({
     name: 'static_stack_pressure',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   staticStackPressure: number;
 
-  @Column({ name: 'percent_co2', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'percent_co2',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   percentCO2: number;
 
-  @Column({ name: 'percent_o2', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'percent_o2',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   percentO2: number;
 
   @Column({
     name: 'percent_moisture',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   percentMoisture: number;
 
   @Column({
     name: 'dry_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   dryMolecularWeight: number;
 
   @Column({
     name: 'calc_dry_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedDryMolecularWeight: number;
 
   @Column({
     name: 'wet_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   wetMolecularWeight: number;
 
   @Column({
     name: 'calc_wet_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedWetMolecularWeight: number;
 
   @Column({
     name: 'avg_vel_wo_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageVelocityWithoutWallEffects: number;
 
   @Column({
     name: 'calc_avg_vel_wo_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageVelocityWithoutWallEffects: number;
 
   @Column({
     name: 'avg_vel_w_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageVelocityWithWallEffects: number;
 
   @Column({
     name: 'calc_avg_vel_w_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageVelocityWithWallEffects: number;
 
-  @Column({ name: 'calc_waf', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'calc_waf',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   calculatedWAF: number;
 
   @Column({
     name: 'calc_calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedCalculatedWAF: number;
 
   @Column({
     name: 'avg_stack_flow_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageStackFlowRate: number;
 

--- a/src/entities/flow-to-load-check.entity.ts
+++ b/src/entities/flow-to-load-check.entity.ts
@@ -44,54 +44,63 @@ export class FlowToLoadCheck extends BaseEntity {
   @Column({
     name: 'bias_adjusted_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   biasAdjustedIndicator: number;
 
   @Column({
     name: 'avg_abs_pct_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageAbsolutePercentDifference: number;
 
   @Column({
     name: 'num_hrs',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHours: number;
 
   @Column({
     name: 'nhe_fuel',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedForFuel: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_bypass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedBypass: number;
 
   @Column({
     name: 'nhe_pre_rata',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedPreRATA: number;
 
   @Column({
     name: 'nhe_test',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedTest: number;
 
   @Column({
     name: 'nhe_main_bypass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcMainBypass: number;
 

--- a/src/entities/flow-to-load-reference.entity.ts
+++ b/src/entities/flow-to-load-reference.entity.ts
@@ -38,60 +38,70 @@ export class FlowToLoadReference extends BaseEntity {
   @Column({
     name: 'avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageGrossUnitLoad: number;
 
   @Column({
     name: 'calc_avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageGrossUnitLoad: number;
 
   @Column({
     name: 'avg_ref_method_flow',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageReferenceMethodFlow: number;
 
   @Column({
     name: 'calc_avg_ref_method_flow',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageReferenceMethodFlow: number;
 
   @Column({
     name: 'ref_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceFlowLoadRatio: number;
 
   @Column({
     name: 'calc_ref_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedReferenceFlowToLoadRatio: number;
 
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'ref_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceGrossHeatRate: number;
 
   @Column({
     name: 'calc_ref_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedReferenceGrossHeatRate: number;
 
   @Column({
     name: 'calc_sep_ref_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedSeparateReferenceIndicator: number;
 

--- a/src/entities/fuel-flow-to-load-baseline.entity.ts
+++ b/src/entities/fuel-flow-to-load-baseline.entity.ts
@@ -35,18 +35,21 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'avg_fuel_flow_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageFuelFlowRate: number;
 
   @Column({
     name: 'avg_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageLoad: number;
 
   @Column({
     name: 'baseline_fuel_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   baselineFuelFlowToLoadRatio: number;
 
@@ -58,12 +61,14 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'baseline_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   baselineGHR: number;
 
@@ -75,18 +80,21 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'nhe_cofiring',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedCofiring: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_low_range',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedLowRange: number;
 

--- a/src/entities/fuel-flow-to-load-test.entity.ts
+++ b/src/entities/fuel-flow-to-load-test.entity.ts
@@ -31,30 +31,35 @@ export class FuelFlowToLoadTest extends BaseEntity {
   @Column({
     name: 'avg_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageDifference: number;
 
   @Column({
     name: 'num_hrs',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursUsed: number;
 
   @Column({
     name: 'nhe_cofiring',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedCofiring: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_low_range',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedLowRange: number;
 

--- a/src/entities/fuel-flowmeter-accuracy.entity.ts
+++ b/src/entities/fuel-flowmeter-accuracy.entity.ts
@@ -38,24 +38,28 @@ export class FuelFlowmeterAccuracy extends BaseEntity {
   @Column({
     name: 'reinstall_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reinstallationHour: number;
 
   @Column({
     name: 'low_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   lowFuelAccuracy: number;
 
   @Column({
     name: 'mid_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   midFuelAccuracy: number;
 
   @Column({
     name: 'high_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   highFuelAccuracy: number;
 

--- a/src/entities/gas-component-code.entity.ts
+++ b/src/entities/gas-component-code.entity.ts
@@ -16,12 +16,14 @@ export class GasComponentCode {
   @Column({
     name: 'can_combine_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   canCombineIndicator: number;
 
   @Column({
     name: 'balance_component_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   balanceComponentIndicator: number;
 

--- a/src/entities/hg-injection.entity.ts
+++ b/src/entities/hg-injection.entity.ts
@@ -33,24 +33,28 @@ export class HgInjection extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'injection_hour',
   })
   injectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'injection_min',
   })
   injectionMinute: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'measured_value',
   })
   measuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'ref_value',
   })
   referenceValue: number;

--- a/src/entities/hg-summary.entity.ts
+++ b/src/entities/hg-summary.entity.ts
@@ -37,48 +37,56 @@ export class HgSummary extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mean_measured_value',
   })
   meanMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_mean_measured_value',
   })
   calculatedMeanMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mean_ref_value',
   })
   meanReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_mean_ref_value',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'percent_error',
   })
   percentError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_percent_error',
   })
   calculatedPercentError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'aps_ind',
   })
   apsIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_aps_ind',
   })
   calculatedAPSIndicator: number;

--- a/src/entities/linearity-injection.entity.ts
+++ b/src/entities/linearity-injection.entity.ts
@@ -32,24 +32,28 @@ export class LinearityInjection extends BaseEntity {
   @Column({
     name: 'injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   injectionHour: number;
 
   @Column({
     name: 'injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   injectionMinute: number;
 
   @Column({
     name: 'measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   measuredValue: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 

--- a/src/entities/linearity-summary.entity.ts
+++ b/src/entities/linearity-summary.entity.ts
@@ -28,48 +28,56 @@ export class LinearitySummary extends BaseEntity {
   @Column({
     name: 'mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanReferenceValue: number;
 
   @Column({
     name: 'calc_mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     name: 'mean_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanMeasuredValue: number;
 
   @Column({
     name: 'calc_mean_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanMeasuredValue: number;
 
   @Column({
     name: 'percent_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   percentError: number;
 
   @Column({
     name: 'calc_percent_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedPercentError: number;
 
   @Column({
     name: 'aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   apsIndicator: number;
 
   @Column({
     name: 'calc_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAPSIndicator: number;
 

--- a/src/entities/mats-data-submission.entity.ts
+++ b/src/entities/mats-data-submission.entity.ts
@@ -55,16 +55,28 @@ export class MatsDataSubmission extends BaseEntity {
   @Column({ name: 'original_sub_id' })
   originalSubmissionId: string;
 
-  @Column({ name: 'fac_id', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'fac_id',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   facilityId: number;
 
   @Column({ name: 'mats_status_cd' })
   statusCode: string;
 
-  @Column({ name: 'year', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'year',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   year: number;
 
-  @Column({ name: 'quarter', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'quarter',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   quarter: number;
 
   @Column({ name: 'user_id' })
@@ -125,9 +137,6 @@ export class MatsDataSubmission extends BaseEntity {
   })
   testMethods: MatsTestMethodCode[];
 
-  @OneToMany(
-    () => MatsDataSubmissionPayloadFile,
-    file => file.submission,
-  )
+  @OneToMany(() => MatsDataSubmissionPayloadFile, (file) => file.submission)
   payloadFiles: MatsDataSubmissionPayloadFile[];
 }

--- a/src/entities/mats-test-method-code.entity.ts
+++ b/src/entities/mats-test-method-code.entity.ts
@@ -21,6 +21,7 @@ export class MatsTestMethodCode extends BaseEntity {
   @Column({
     name: 'display_order',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   displayOrder: number;
 

--- a/src/entities/monitor-method.entity.ts
+++ b/src/entities/monitor-method.entity.ts
@@ -41,13 +41,18 @@ export class MonitorMethod extends BaseEntity {
     nullable: false,
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endHour: number;
 
   @Column({ type: 'varchar', nullable: true, length: 8, name: 'userid' })

--- a/src/entities/online-offline-calibration.entity.ts
+++ b/src/entities/online-offline-calibration.entity.ts
@@ -40,42 +40,49 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_injection_hour',
   })
   onlineZeroInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_cal_error',
   })
   onlineZeroCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_aps_ind',
   })
   onlineZeroAPSIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_measured_value',
   })
   onlineZeroMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_ref_value',
   })
   onlineZeroReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_cal_error',
   })
   onlineUpscaleCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_aps_ind',
   })
   onlineUpscaleAPSIndicator: number;
@@ -88,18 +95,21 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_injection_hour',
   })
   onlineUpscaleInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_measured_value',
   })
   onlineUpscaleMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_ref_value',
   })
   onlineUpscaleReferenceValue: number;
@@ -112,42 +122,49 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_injection_hour',
   })
   offlineZeroInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_cal_error',
   })
   offlineZeroCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_aps_ind',
   })
   offlineZeroAPSIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_measured_value',
   })
   offlineZeroMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_ref_value',
   })
   offlineZeroReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_cal_error',
   })
   offlineUpscaleCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_aps_ind',
   })
   offlineUpscaleAPSIndicator: number;
@@ -160,18 +177,21 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_injection_hour',
   })
   offlineUpscaleInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_measured_value',
   })
   offlineUpscaleMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_ref_value',
   })
   offlineUpscaleReferenceValue: number;

--- a/src/entities/plant.entity.ts
+++ b/src/entities/plant.entity.ts
@@ -17,12 +17,14 @@ export class Plant extends BaseEntity {
   @PrimaryColumn({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 
   @Column({
     name: 'oris_code',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   orisCode: number;
 

--- a/src/entities/qa-supp-data.entity.ts
+++ b/src/entities/qa-supp-data.entity.ts
@@ -70,12 +70,14 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -88,18 +90,21 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -111,6 +116,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   gracePeriodIndicator: number;
 
@@ -123,6 +129,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'reinstallation_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reinstallationHour: number;
 
@@ -135,6 +142,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'test_expire_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   testExpireHour: number;
 
@@ -167,6 +175,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   submissionId: number;
 

--- a/src/entities/rata-run.entity.ts
+++ b/src/entities/rata-run.entity.ts
@@ -19,45 +19,72 @@ export class RataRun extends BaseEntity {
   @Column({ name: 'rata_sum_id' })
   rataSumId: string;
 
-  @Column({ name: 'run_num', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'run_num',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   runNumber: number;
 
   @Column({ type: 'date', name: 'begin_date' })
   beginDate: Date;
 
-  @Column({ name: 'begin_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'begin_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   beginHour: number;
 
-  @Column({ name: 'begin_min', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'begin_min',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   beginMinute: number;
 
   @Column({ type: 'date', name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endHour: number;
 
-  @Column({ name: 'end_min', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_min',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endMinute: number;
 
-  @Column({ name: 'cem_value', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'cem_value',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   cemValue: number;
 
   @Column({
     name: 'rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   rataReferenceValue: number;
 
   @Column({
     name: 'calc_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRataReferenceValue: number;
 
   @Column({
     name: 'gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   grossUnitLoad: number;
 
@@ -77,17 +104,11 @@ export class RataRun extends BaseEntity {
   })
   updateDate: Date;
 
-  @ManyToOne(
-    () => RataSummary,
-    r => r.RataRuns,
-  )
+  @ManyToOne(() => RataSummary, (r) => r.RataRuns)
   @JoinColumn({ name: 'rata_sum_id' })
   RataSummary: RataSummary;
 
-  @OneToMany(
-    () => FlowRataRun,
-    r => r.RataRun,
-  )
+  @OneToMany(() => FlowRataRun, (r) => r.RataRun)
   @JoinColumn({ name: 'rata_run_id' })
   FlowRataRuns: FlowRataRun[];
 }

--- a/src/entities/rata-summary.entity.ts
+++ b/src/entities/rata-summary.entity.ts
@@ -33,12 +33,14 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageGrossUnitLoad: number;
 
   @Column({
     name: 'calc_avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageGrossUnitLoad: number;
 
@@ -50,84 +52,98 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'mean_cem_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanCEMValue: number;
 
   @Column({
     name: 'calc_mean_cem_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanCEMValue: number;
 
   @Column({
     name: 'mean_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanRATAReferenceValue: number;
 
   @Column({
     name: 'calc_mean_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanRATAReferenceValue: number;
 
   @Column({
     name: 'mean_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanDifference: number;
 
   @Column({
     name: 'calc_mean_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanDifference: number;
 
   @Column({
     name: 'stnd_dev_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   standardDeviationDifference: number;
 
   @Column({
     name: 'calc_stnd_dev_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedStandardDeviationDifference: number;
 
   @Column({
     name: 'confidence_coef',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   confidenceCoefficient: number;
 
   @Column({
     name: 'calc_confidence_coef',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedConfidenceCoefficient: number;
 
   @Column({
     name: 't_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   tValue: number;
 
   @Column({
     name: 'calc_t_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedTValue: number;
 
   @Column({
     name: 'aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   apsIndicator: number;
 
   @Column({
     name: 'calc_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedApsIndicator: number;
 
@@ -139,24 +155,28 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   relativeAccuracy: number;
 
   @Column({
     name: 'calc_relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRelativeAccuracy: number;
 
   @Column({
     name: 'bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   biasAdjustmentFactor: number;
 
   @Column({
     name: 'calc_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedBiasAdjustmentFactor: number;
 
@@ -168,42 +188,49 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'stack_diameter',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   stackDiameter: number;
 
   @Column({
     name: 'stack_area',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   stackArea: number;
 
   @Column({
     name: 'calc_stack_area',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedStackArea: number;
 
   @Column({
     name: 'num_traverse_point',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfTraversePoints: number;
 
   @Column({
     name: 'calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedWAF: number;
 
   @Column({
     name: 'calc_calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedCalculatedWAF: number;
 
   @Column({
     name: 'default_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   defaultWAF: number;
 

--- a/src/entities/rata.entity.ts
+++ b/src/entities/rata.entity.ts
@@ -38,36 +38,42 @@ export class Rata extends BaseEntity {
   @Column({
     name: 'relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   relativeAccuracy: number;
 
   @Column({
     name: 'calc_relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRelativeAccuracy: number;
 
   @Column({
     name: 'overall_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   overallBiasAdjustmentFactor: number;
 
   @Column({
     name: 'calc_overall_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOverallBiasAdjustmentFactor: number;
 
   @Column({
     name: 'num_load_level',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfLoadLevels: number;
 
   @Column({
     name: 'calc_num_load_level',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedNumberOfLoadLevels: number;
 

--- a/src/entities/reporting-period.entity.ts
+++ b/src/entities/reporting-period.entity.ts
@@ -17,18 +17,21 @@ export class ReportingPeriod extends BaseEntity {
   @PrimaryColumn({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 
   @Column({
     name: 'calendar_year',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   year: number;
 
   @Column({
     name: 'quarter',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   quarter: number;
 

--- a/src/entities/stack-pipe.entity.ts
+++ b/src/entities/stack-pipe.entity.ts
@@ -40,6 +40,7 @@ export class StackPipe extends BaseEntity {
   @Column({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   facId: number;
 

--- a/src/entities/test-extension-exemption.entity.ts
+++ b/src/entities/test-extension-exemption.entity.ts
@@ -29,6 +29,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -70,6 +71,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'hours_used',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   hoursUsed: number;
 
@@ -96,6 +98,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   submissionId: string;
 

--- a/src/entities/test-qualification.entity.ts
+++ b/src/entities/test-qualification.entity.ts
@@ -31,18 +31,21 @@ export class TestQualification extends BaseEntity {
   @Column({
     name: 'hi_load_pct',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   highLoadPercentage: number;
 
   @Column({
     name: 'mid_load_pct',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   midLoadPercentage: number;
 
   @Column({
     name: 'low_load_pct',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   lowLoadPercentage: number;
 

--- a/src/entities/test-summary.entity.ts
+++ b/src/entities/test-summary.entity.ts
@@ -62,12 +62,14 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   gracePeriodIndicator: number;
 
   @Column({
     name: 'calc_gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedGracePeriodIndicator: number;
 
@@ -94,6 +96,7 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -111,12 +114,14 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -129,18 +134,21 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'calc_span_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedSpanValue: number;
 

--- a/src/entities/transmitter-transducer-accuracy.entity.ts
+++ b/src/entities/transmitter-transducer-accuracy.entity.ts
@@ -28,6 +28,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'low_level_accuracy',
   })
   lowLevelAccuracy: number;
@@ -40,6 +41,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mid_level_accuracy',
   })
   midLevelAccuracy: number;
@@ -52,6 +54,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'high_level_accuracy',
   })
   highLevelAccuracy: number;

--- a/src/entities/unit-default-test-run.entity.ts
+++ b/src/entities/unit-default-test-run.entity.ts
@@ -30,12 +30,14 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'op_level_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   operatingLevelForRun: number;
 
   @Column({
     name: 'run_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runNumber: number;
 
@@ -48,12 +50,14 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -66,30 +70,35 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'response_time',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   responseTime: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 
   @Column({
     name: 'run_used_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runUsedIndicator: number;
 

--- a/src/entities/unit-default-test.entity.ts
+++ b/src/entities/unit-default-test.entity.ts
@@ -38,12 +38,14 @@ export class UnitDefaultTest extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'nox_default_rate',
   })
   noxDefaultRate: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_nox_default_rate',
   })
   calculatedNoxDefaultRate: number;
@@ -62,12 +64,14 @@ export class UnitDefaultTest extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'num_units_in_group',
   })
   numberOfUnitsInGroup: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'num_tests_for_group',
   })
   numberOfTestsForGroup: number;

--- a/src/entities/unit.entity.ts
+++ b/src/entities/unit.entity.ts
@@ -18,6 +18,7 @@ export class Unit extends BaseEntity {
   @PrimaryColumn({
     name: 'unit_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 

--- a/src/entities/workspace/analyzerRange.entity.ts
+++ b/src/entities/workspace/analyzerRange.entity.ts
@@ -33,6 +33,7 @@ export class AnalyzerRange extends BaseEntity {
   @Column({
     name: 'dual_range_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   dualRangeIndicator: number;
 
@@ -42,10 +43,18 @@ export class AnalyzerRange extends BaseEntity {
   @Column({ type: 'date', nullable: true, name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'begin_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'begin_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   beginHour: number;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endHour: number;
 
   @Column({
@@ -61,10 +70,7 @@ export class AnalyzerRange extends BaseEntity {
   @Column({ type: 'timestamp', name: 'update_date' })
   updateDate: Date;
 
-  @ManyToOne(
-    () => Component,
-    c => c.analyzerRanges,
-  )
+  @ManyToOne(() => Component, (c) => c.analyzerRanges)
   @JoinColumn({ name: 'component_id' })
   component: Component;
 }

--- a/src/entities/workspace/app-e-correlation-test-run.entity.ts
+++ b/src/entities/workspace/app-e-correlation-test-run.entity.ts
@@ -28,42 +28,49 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'run_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runNumber: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 
   @Column({
     name: 'hourly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   hourlyHeatInputRate: number;
 
   @Column({
     name: 'calc_hourly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedHourlyHeatInputRate: number;
 
   @Column({
     name: 'total_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   totalHeatInput: number;
 
   @Column({
     name: 'calc_total_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedTotalHeatInput: number;
 
   @Column({
     name: 'response_time',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   responseTime: number;
 
@@ -76,12 +83,14 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -94,12 +103,14 @@ export class AppECorrelationTestRun extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 

--- a/src/entities/workspace/app-e-correlation-test-summary.entity.ts
+++ b/src/entities/workspace/app-e-correlation-test-summary.entity.ts
@@ -35,36 +35,42 @@ export class AppECorrelationTestSummary extends BaseEntity {
   @Column({
     name: 'op_level_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   operatingLevelForRun: number;
 
   @Column({
     name: 'mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanReferenceValue: number;
 
   @Column({
     name: 'calc_mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'calc_avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageHourlyHeatInputRate: number;
 
   @Column({
     name: 'f_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   fFactor: number;
 

--- a/src/entities/workspace/app-e-heat-input-from-gas.entity.ts
+++ b/src/entities/workspace/app-e-heat-input-from-gas.entity.ts
@@ -78,15 +78,12 @@ export class AppEHeatInputFromGas extends BaseEntity {
 
   @ManyToOne(
     () => AppECorrelationTestRun,
-    aectr => aectr.appEHeatInputFromGases,
+    (aectr) => aectr.appEHeatInputFromGases,
   )
   @JoinColumn({ name: 'ae_corr_test_run_id' })
   appECorrelationTestRun: AppECorrelationTestRun;
 
-  @ManyToOne(
-    () => MonitorSystem,
-    ms => ms.appEHeatInputFromGases,
-  )
+  @ManyToOne(() => MonitorSystem, (ms) => ms.appEHeatInputFromGases)
   @JoinColumn({ name: 'mon_sys_id' })
   system: MonitorSystem;
 }

--- a/src/entities/workspace/app-e-heat-input-from-oil.entity.ts
+++ b/src/entities/workspace/app-e-heat-input-from-oil.entity.ts
@@ -35,30 +35,35 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_mass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilMass: number;
 
   @Column({
     name: 'calc_oil_mass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOilMass: number;
 
   @Column({
     name: 'oil_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilHeatInput: number;
 
   @Column({
     name: 'calc_oil_hi',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOilHeatInput: number;
 
   @Column({
     name: 'oil_gcv',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilGCV: number;
 
@@ -70,6 +75,7 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_volume',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilVolume: number;
 
@@ -81,6 +87,7 @@ export class AppEHeatInputFromOil extends BaseEntity {
   @Column({
     name: 'oil_density',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   oilDensity: number;
 

--- a/src/entities/workspace/calibration-injection.entity.ts
+++ b/src/entities/workspace/calibration-injection.entity.ts
@@ -29,36 +29,42 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'online_offline_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   onlineOfflineIndicator: number;
 
   @Column({
     name: 'zero_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroReferenceValue: number;
 
   @Column({
     name: 'zero_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroCalibrationError: number;
 
   @Column({
     name: 'calc_zero_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedZeroCalibrationError: number;
 
   @Column({
     name: 'zero_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroAPSIndicator: number;
 
   @Column({
     name: 'calc_zero_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedZeroAPSIndicator: number;
 
@@ -71,24 +77,28 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'zero_injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroInjectionHour: number;
 
   @Column({
     name: 'zero_injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroInjectionMinute: number;
 
   @Column({
     name: 'upscale_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleReferenceValue: number;
 
   @Column({
     name: 'zero_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   zeroMeasuredValue: number;
 
@@ -101,30 +111,35 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'upscale_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleMeasuredValue: number;
 
   @Column({
     name: 'upscale_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleCalibrationError: number;
 
   @Column({
     name: 'calc_upscale_cal_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedUpscaleCalibrationError: number;
 
   @Column({
     name: 'upscale_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleAPSIndicator: number;
 
   @Column({
     name: 'calc_upscale_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedUpscaleAPSIndicator: number;
 
@@ -137,12 +152,14 @@ export class CalibrationInjection extends BaseEntity {
   @Column({
     name: 'upscale_injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleInjectionHour: number;
 
   @Column({
     name: 'upscale_injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   upscaleInjectionMinute: number;
 

--- a/src/entities/workspace/cycle-time-injection.entity.ts
+++ b/src/entities/workspace/cycle-time-injection.entity.ts
@@ -122,10 +122,7 @@ export class CycleTimeInjection extends BaseEntity {
   })
   updateDate: Date;
 
-  @ManyToOne(
-    () => CycleTimeSummary,
-    o => o.cycleTimeInjections,
-  )
+  @ManyToOne(() => CycleTimeSummary, (o) => o.cycleTimeInjections)
   @JoinColumn({ name: 'cycle_time_sum_id' })
   cycleTimeSummary: CycleTimeSummary;
 }

--- a/src/entities/workspace/cycle-time-summary.entity.ts
+++ b/src/entities/workspace/cycle-time-summary.entity.ts
@@ -31,12 +31,14 @@ export class CycleTimeSummary extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'total_time',
   })
   totalTime: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_total_time',
   })
   calculatedTotalTime: number;

--- a/src/entities/workspace/flow-rata-run.entity.ts
+++ b/src/entities/workspace/flow-rata-run.entity.ts
@@ -22,93 +22,119 @@ export class FlowRataRun extends BaseEntity {
   @Column({
     name: 'num_traverse_point',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfTraversePoints: number;
 
   @Column({
     name: 'barometric_pressure',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   barometricPressure: number;
 
   @Column({
     name: 'static_stack_pressure',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   staticStackPressure: number;
 
-  @Column({ name: 'percent_co2', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'percent_co2',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   percentCO2: number;
 
-  @Column({ name: 'percent_o2', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'percent_o2',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   percentO2: number;
 
   @Column({
     name: 'percent_moisture',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   percentMoisture: number;
 
   @Column({
     name: 'dry_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   dryMolecularWeight: number;
 
   @Column({
     name: 'calc_dry_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedDryMolecularWeight: number;
 
   @Column({
     name: 'wet_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   wetMolecularWeight: number;
 
   @Column({
     name: 'calc_wet_molecular_weight',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedWetMolecularWeight: number;
 
   @Column({
     name: 'avg_vel_wo_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageVelocityWithoutWallEffects: number;
 
   @Column({
     name: 'calc_avg_vel_wo_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageVelocityWithoutWallEffects: number;
 
   @Column({
     name: 'avg_vel_w_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageVelocityWithWallEffects: number;
 
   @Column({
     name: 'calc_avg_vel_w_wall',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageVelocityWithWallEffects: number;
 
-  @Column({ name: 'calc_waf', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'calc_waf',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   calculatedWAF: number;
 
   @Column({
     name: 'calc_calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedCalculatedWAF: number;
 
   @Column({
     name: 'avg_stack_flow_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageStackFlowRate: number;
 
@@ -121,17 +147,11 @@ export class FlowRataRun extends BaseEntity {
   @Column({ name: 'update_date' })
   updateDate: Date;
 
-  @ManyToOne(
-    () => RataRun,
-    f => f.FlowRataRuns,
-  )
+  @ManyToOne(() => RataRun, (f) => f.FlowRataRuns)
   @JoinColumn({ name: 'rata_run_id' })
   RataRun: RataRun;
 
-  @OneToMany(
-    () => RataTraverse,
-    rt => rt.FlowRataRun,
-  )
+  @OneToMany(() => RataTraverse, (rt) => rt.FlowRataRun)
   @JoinColumn({ name: 'flow_rata_run_id' })
   RataTraverses: RataTraverse[];
 }

--- a/src/entities/workspace/flow-to-load-check.entity.ts
+++ b/src/entities/workspace/flow-to-load-check.entity.ts
@@ -44,54 +44,63 @@ export class FlowToLoadCheck extends BaseEntity {
   @Column({
     name: 'bias_adjusted_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   biasAdjustedIndicator: number;
 
   @Column({
     name: 'avg_abs_pct_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageAbsolutePercentDifference: number;
 
   @Column({
     name: 'num_hrs',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHours: number;
 
   @Column({
     name: 'nhe_fuel',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedForFuel: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_bypass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedBypass: number;
 
   @Column({
     name: 'nhe_pre_rata',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedPreRATA: number;
 
   @Column({
     name: 'nhe_test',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedTest: number;
 
   @Column({
     name: 'nhe_main_bypass',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcMainBypass: number;
 

--- a/src/entities/workspace/flow-to-load-reference.entity.ts
+++ b/src/entities/workspace/flow-to-load-reference.entity.ts
@@ -38,60 +38,70 @@ export class FlowToLoadReference extends BaseEntity {
   @Column({
     name: 'avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageGrossUnitLoad: number;
 
   @Column({
     name: 'calc_avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageGrossUnitLoad: number;
 
   @Column({
     name: 'avg_ref_method_flow',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageReferenceMethodFlow: number;
 
   @Column({
     name: 'calc_avg_ref_method_flow',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageReferenceMethodFlow: number;
 
   @Column({
     name: 'ref_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceFlowLoadRatio: number;
 
   @Column({
     name: 'calc_ref_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedReferenceFlowToLoadRatio: number;
 
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'ref_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceGrossHeatRate: number;
 
   @Column({
     name: 'calc_ref_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedReferenceGrossHeatRate: number;
 
   @Column({
     name: 'calc_sep_ref_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedSeparateReferenceIndicator: number;
 

--- a/src/entities/workspace/fuel-flow-to-load-baseline.entity.ts
+++ b/src/entities/workspace/fuel-flow-to-load-baseline.entity.ts
@@ -35,18 +35,21 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'avg_fuel_flow_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageFuelFlowRate: number;
 
   @Column({
     name: 'avg_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageLoad: number;
 
   @Column({
     name: 'baseline_fuel_flow_load_ratio',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   baselineFuelFlowToLoadRatio: number;
 
@@ -58,12 +61,14 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'avg_hrly_hi_rate',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageHourlyHeatInputRate: number;
 
   @Column({
     name: 'baseline_ghr',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   baselineGHR: number;
 
@@ -75,18 +80,21 @@ export class FuelFlowToLoadBaseline extends BaseEntity {
   @Column({
     name: 'nhe_cofiring',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedCofiring: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_low_range',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedLowRange: number;
 

--- a/src/entities/workspace/fuel-flow-to-load-test.entity.ts
+++ b/src/entities/workspace/fuel-flow-to-load-test.entity.ts
@@ -31,30 +31,35 @@ export class FuelFlowToLoadTest extends BaseEntity {
   @Column({
     name: 'avg_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageDifference: number;
 
   @Column({
     name: 'num_hrs',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursUsed: number;
 
   @Column({
     name: 'nhe_cofiring',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedCofiring: number;
 
   @Column({
     name: 'nhe_ramping',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedRamping: number;
 
   @Column({
     name: 'nhe_low_range',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfHoursExcludedLowRange: number;
 

--- a/src/entities/workspace/fuel-flowmeter-accuracy.entity.ts
+++ b/src/entities/workspace/fuel-flowmeter-accuracy.entity.ts
@@ -38,24 +38,28 @@ export class FuelFlowmeterAccuracy extends BaseEntity {
   @Column({
     name: 'reinstall_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reinstallationHour: number;
 
   @Column({
     name: 'low_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   lowFuelAccuracy: number;
 
   @Column({
     name: 'mid_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   midFuelAccuracy: number;
 
   @Column({
     name: 'high_fuel_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   highFuelAccuracy: number;
 

--- a/src/entities/workspace/hg-injection.entity.ts
+++ b/src/entities/workspace/hg-injection.entity.ts
@@ -33,24 +33,28 @@ export class HgInjection extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'injection_hour',
   })
   injectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'injection_min',
   })
   injectionMinute: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'measured_value',
   })
   measuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'ref_value',
   })
   referenceValue: number;

--- a/src/entities/workspace/hg-summary.entity.ts
+++ b/src/entities/workspace/hg-summary.entity.ts
@@ -37,48 +37,56 @@ export class HgSummary extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mean_measured_value',
   })
   meanMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_mean_measured_value',
   })
   calculatedMeanMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mean_ref_value',
   })
   meanReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_mean_ref_value',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'percent_error',
   })
   percentError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_percent_error',
   })
   calculatedPercentError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'aps_ind',
   })
   apsIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_aps_ind',
   })
   calculatedAPSIndicator: number;

--- a/src/entities/workspace/linearity-injection.entity.ts
+++ b/src/entities/workspace/linearity-injection.entity.ts
@@ -32,24 +32,28 @@ export class LinearityInjection extends BaseEntity {
   @Column({
     name: 'injection_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   injectionHour: number;
 
   @Column({
     name: 'injection_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   injectionMinute: number;
 
   @Column({
     name: 'measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   measuredValue: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 

--- a/src/entities/workspace/linearity-summary.entity.ts
+++ b/src/entities/workspace/linearity-summary.entity.ts
@@ -28,48 +28,56 @@ export class LinearitySummary extends BaseEntity {
   @Column({
     name: 'mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanReferenceValue: number;
 
   @Column({
     name: 'calc_mean_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanReferenceValue: number;
 
   @Column({
     name: 'mean_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanMeasuredValue: number;
 
   @Column({
     name: 'calc_mean_measured_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanMeasuredValue: number;
 
   @Column({
     name: 'percent_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   percentError: number;
 
   @Column({
     name: 'calc_percent_error',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedPercentError: number;
 
   @Column({
     name: 'aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   apsIndicator: number;
 
   @Column({
     name: 'calc_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAPSIndicator: number;
 

--- a/src/entities/workspace/monitor-method.entity.ts
+++ b/src/entities/workspace/monitor-method.entity.ts
@@ -41,13 +41,18 @@ export class MonitorMethod extends BaseEntity {
     nullable: false,
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({ type: 'date', name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({
+    name: 'end_hour',
+    transformer: new NumericColumnTransformer(),
+    type: 'numeric',
+  })
   endHour: number;
 
   @Column({ type: 'varchar', nullable: true, length: 8, name: 'userid' })
@@ -59,10 +64,7 @@ export class MonitorMethod extends BaseEntity {
   @Column({ type: 'timestamp', nullable: true, name: 'update_date' })
   updateDate: Date;
 
-  @ManyToOne(
-    () => MonitorLocation,
-    location => location.methods,
-  )
+  @ManyToOne(() => MonitorLocation, (location) => location.methods)
   @JoinColumn({ name: 'mon_loc_id' })
   location: MonitorLocation;
 }

--- a/src/entities/workspace/online-offline-calibration.entity.ts
+++ b/src/entities/workspace/online-offline-calibration.entity.ts
@@ -40,42 +40,49 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_injection_hour',
   })
   onlineZeroInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_cal_error',
   })
   onlineZeroCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_aps_ind',
   })
   onlineZeroAPSIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_measured_value',
   })
   onlineZeroMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_zero_ref_value',
   })
   onlineZeroReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_cal_error',
   })
   onlineUpscaleCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_aps_ind',
   })
   onlineUpscaleAPSIndicator: number;
@@ -88,18 +95,21 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_injection_hour',
   })
   onlineUpscaleInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_measured_value',
   })
   onlineUpscaleMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'online_upscale_ref_value',
   })
   onlineUpscaleReferenceValue: number;
@@ -112,42 +122,49 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_injection_hour',
   })
   offlineZeroInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_cal_error',
   })
   offlineZeroCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_aps_ind',
   })
   offlineZeroAPSIndicator: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_measured_value',
   })
   offlineZeroMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_zero_ref_value',
   })
   offlineZeroReferenceValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_cal_error',
   })
   offlineUpscaleCalibrationError: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_aps_ind',
   })
   offlineUpscaleAPSIndicator: number;
@@ -160,18 +177,21 @@ export class OnlineOfflineCalibration extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_injection_hour',
   })
   offlineUpscaleInjectionHour: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_measured_value',
   })
   offlineUpscaleMeasuredValue: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'offline_upscale_ref_value',
   })
   offlineUpscaleReferenceValue: number;

--- a/src/entities/workspace/plant.entity.ts
+++ b/src/entities/workspace/plant.entity.ts
@@ -17,12 +17,14 @@ export class Plant extends BaseEntity {
   @PrimaryColumn({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 
   @Column({
     name: 'oris_code',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   orisCode: number;
 

--- a/src/entities/workspace/protocol-gas-vendor.entity.ts
+++ b/src/entities/workspace/protocol-gas-vendor.entity.ts
@@ -18,6 +18,7 @@ export class ProtocolGasVendor extends BaseEntity {
   @Column({
     name: 'active_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   activeIndicator: number;
 

--- a/src/entities/workspace/qa-certification-event.entity.ts
+++ b/src/entities/workspace/qa-certification-event.entity.ts
@@ -156,24 +156,15 @@ export class QACertificationEvent extends BaseEntity {
   })
   updateDate: Date;
 
-  @ManyToOne(
-    () => MonitorLocation,
-    o => o.qaCertEvents,
-  )
+  @ManyToOne(() => MonitorLocation, (o) => o.qaCertEvents)
   @JoinColumn({ name: 'mon_loc_id' })
   location: MonitorLocation;
 
-  @ManyToOne(
-    () => Component,
-    o => o.qaCertEvents,
-  )
+  @ManyToOne(() => Component, (o) => o.qaCertEvents)
   @JoinColumn({ name: 'component_id' })
   component: Component;
 
-  @ManyToOne(
-    () => MonitorSystem,
-    o => o.qaCertEvents,
-  )
+  @ManyToOne(() => MonitorSystem, (o) => o.qaCertEvents)
   @JoinColumn({ name: 'mon_sys_id' })
   system: MonitorSystem;
 }

--- a/src/entities/workspace/qa-supp-data.entity.ts
+++ b/src/entities/workspace/qa-supp-data.entity.ts
@@ -70,12 +70,14 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -88,18 +90,21 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -111,6 +116,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   gracePeriodIndicator: number;
 
@@ -123,6 +129,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'reinstallation_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reinstallationHour: number;
 
@@ -135,6 +142,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'test_expire_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   testExpireHour: number;
 
@@ -167,6 +175,7 @@ export class QASuppData extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   submissionId: number;
 

--- a/src/entities/workspace/rata-run.entity.ts
+++ b/src/entities/workspace/rata-run.entity.ts
@@ -19,45 +19,54 @@ export class RataRun extends BaseEntity {
   @Column({ name: 'rata_sum_id' })
   rataSumId: string;
 
-  @Column({ name: 'run_num', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'run_num', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   runNumber: number;
 
   @Column({ type: 'date', name: 'begin_date' })
   beginDate: Date;
 
-  @Column({ name: 'begin_hour', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'begin_hour', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   beginHour: number;
 
-  @Column({ name: 'begin_min', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'begin_min', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   beginMinute: number;
 
   @Column({ type: 'date', name: 'end_date' })
   endDate: Date;
 
-  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'end_hour', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   endHour: number;
 
-  @Column({ name: 'end_min', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'end_min', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   endMinute: number;
 
-  @Column({ name: 'cem_value', transformer: new NumericColumnTransformer() })
+  @Column({ name: 'cem_value', transformer: new NumericColumnTransformer(),
+    type: 'numeric', })
   cemValue: number;
 
   @Column({
     name: 'rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   rataReferenceValue: number;
 
   @Column({
     name: 'calc_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRataReferenceValue: number;
 
   @Column({
     name: 'gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   grossUnitLoad: number;
 

--- a/src/entities/workspace/rata-summary.entity.ts
+++ b/src/entities/workspace/rata-summary.entity.ts
@@ -36,12 +36,14 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   averageGrossUnitLoad: number;
 
   @Column({
     name: 'calc_avg_gross_unit_load',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedAverageGrossUnitLoad: number;
 
@@ -53,84 +55,98 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'mean_cem_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanCEMValue: number;
 
   @Column({
     name: 'calc_mean_cem_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanCEMValue: number;
 
   @Column({
     name: 'mean_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanRATAReferenceValue: number;
 
   @Column({
     name: 'calc_mean_rata_ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanRATAReferenceValue: number;
 
   @Column({
     name: 'mean_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   meanDifference: number;
 
   @Column({
     name: 'calc_mean_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedMeanDifference: number;
 
   @Column({
     name: 'stnd_dev_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   standardDeviationDifference: number;
 
   @Column({
     name: 'calc_stnd_dev_diff',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedStandardDeviationDifference: number;
 
   @Column({
     name: 'confidence_coef',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   confidenceCoefficient: number;
 
   @Column({
     name: 'calc_confidence_coef',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedConfidenceCoefficient: number;
 
   @Column({
     name: 't_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   tValue: number;
 
   @Column({
     name: 'calc_t_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedTValue: number;
 
   @Column({
     name: 'aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   apsIndicator: number;
 
   @Column({
     name: 'calc_aps_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedApsIndicator: number;
 
@@ -142,24 +158,28 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   relativeAccuracy: number;
 
   @Column({
     name: 'calc_relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRelativeAccuracy: number;
 
   @Column({
     name: 'bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   biasAdjustmentFactor: number;
 
   @Column({
     name: 'calc_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedBiasAdjustmentFactor: number;
 
@@ -171,42 +191,49 @@ export class RataSummary extends BaseEntity {
   @Column({
     name: 'stack_diameter',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   stackDiameter: number;
 
   @Column({
     name: 'stack_area',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   stackArea: number;
 
   @Column({
     name: 'calc_stack_area',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedStackArea: number;
 
   @Column({
     name: 'num_traverse_point',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfTraversePoints: number;
 
   @Column({
     name: 'calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedWAF: number;
 
   @Column({
     name: 'calc_calc_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedCalculatedWAF: number;
 
   @Column({
     name: 'default_waf',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   defaultWAF: number;
 

--- a/src/entities/workspace/rata-traverse.entity.ts
+++ b/src/entities/workspace/rata-traverse.entity.ts
@@ -148,10 +148,7 @@ export class RataTraverse extends BaseEntity {
   })
   updateDate: Date;
 
-  @ManyToOne(
-    () => FlowRataRun,
-    fr => fr.RataTraverses,
-  )
+  @ManyToOne(() => FlowRataRun, (fr) => fr.RataTraverses)
   @JoinColumn({ name: 'flow_rata_run_id' })
   FlowRataRun: FlowRataRun;
 }

--- a/src/entities/workspace/rata.entity.ts
+++ b/src/entities/workspace/rata.entity.ts
@@ -39,36 +39,42 @@ export class Rata extends BaseEntity {
   @Column({
     name: 'relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   relativeAccuracy: number;
 
   @Column({
     name: 'calc_relative_accuracy',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedRelativeAccuracy: number;
 
   @Column({
     name: 'overall_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   overallBiasAdjustmentFactor: number;
 
   @Column({
     name: 'calc_overall_bias_adj_factor',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedOverallBiasAdjustmentFactor: number;
 
   @Column({
     name: 'num_load_level',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   numberOfLoadLevels: number;
 
   @Column({
     name: 'calc_num_load_level',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedNumberOfLoadLevels: number;
 

--- a/src/entities/workspace/stack-pipe.entity.ts
+++ b/src/entities/workspace/stack-pipe.entity.ts
@@ -40,6 +40,7 @@ export class StackPipe extends BaseEntity {
   @Column({
     name: 'fac_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   facId: number;
 

--- a/src/entities/workspace/test-extension-exemption.entity.ts
+++ b/src/entities/workspace/test-extension-exemption.entity.ts
@@ -29,6 +29,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -70,6 +71,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'hours_used',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   hoursUsed: number;
 
@@ -96,6 +98,7 @@ export class TestExtensionExemption extends BaseEntity {
   @Column({
     name: 'submission_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   submissionId: string;
 

--- a/src/entities/workspace/test-qualification.entity.ts
+++ b/src/entities/workspace/test-qualification.entity.ts
@@ -83,17 +83,11 @@ export class TestQualification extends BaseEntity {
   })
   updateDate: Date;
 
-  @ManyToOne(
-    () => TestSummary,
-    o => o.testQualifications,
-  )
+  @ManyToOne(() => TestSummary, (o) => o.testQualifications)
   @JoinColumn({ name: 'test_sum_id' })
   testSummary: TestSummary;
 
-  @ManyToOne(
-    () => TestClaimCode,
-    tcc => tcc.TestQualifications,
-  )
+  @ManyToOne(() => TestClaimCode, (tcc) => tcc.TestQualifications)
   @JoinColumn({ name: 'test_claim_cd' })
   TestClaimCode: TestClaimCode;
 }

--- a/src/entities/workspace/test-summary.entity.ts
+++ b/src/entities/workspace/test-summary.entity.ts
@@ -62,12 +62,14 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   gracePeriodIndicator: number;
 
   @Column({
     name: 'calc_gp_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedGracePeriodIndicator: number;
 
@@ -94,6 +96,7 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'rpt_period_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   reportPeriodId: number;
 
@@ -111,12 +114,14 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -129,18 +134,21 @@ export class TestSummary extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'calc_span_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   calculatedSpanValue: number;
 

--- a/src/entities/workspace/transmitter-transducer-accuracy.entity.ts
+++ b/src/entities/workspace/transmitter-transducer-accuracy.entity.ts
@@ -28,6 +28,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'low_level_accuracy',
   })
   lowLevelAccuracy: number;
@@ -40,6 +41,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'mid_level_accuracy',
   })
   midLevelAccuracy: number;
@@ -52,6 +54,7 @@ export class TransmitterTransducerAccuracy extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'high_level_accuracy',
   })
   highLevelAccuracy: number;

--- a/src/entities/workspace/unit-default-test-run.entity.ts
+++ b/src/entities/workspace/unit-default-test-run.entity.ts
@@ -30,12 +30,14 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'op_level_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   operatingLevelForRun: number;
 
   @Column({
     name: 'run_num',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runNumber: number;
 
@@ -48,12 +50,14 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'begin_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginHour: number;
 
   @Column({
     name: 'begin_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   beginMinute: number;
 
@@ -66,30 +70,35 @@ export class UnitDefaultTestRun extends BaseEntity {
   @Column({
     name: 'end_hour',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endHour: number;
 
   @Column({
     name: 'end_min',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   endMinute: number;
 
   @Column({
     name: 'response_time',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   responseTime: number;
 
   @Column({
     name: 'ref_value',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   referenceValue: number;
 
   @Column({
     name: 'run_used_ind',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   runUsedIndicator: number;
 

--- a/src/entities/workspace/unit-default-test.entity.ts
+++ b/src/entities/workspace/unit-default-test.entity.ts
@@ -38,12 +38,14 @@ export class UnitDefaultTest extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'nox_default_rate',
   })
   noxDefaultRate: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'calc_nox_default_rate',
   })
   calculatedNoxDefaultRate: number;
@@ -62,12 +64,14 @@ export class UnitDefaultTest extends BaseEntity {
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'num_units_in_group',
   })
   numberOfUnitsInGroup: number;
 
   @Column({
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
     name: 'num_tests_for_group',
   })
   numberOfTestsForGroup: number;

--- a/src/entities/workspace/unit.entity.ts
+++ b/src/entities/workspace/unit.entity.ts
@@ -18,6 +18,7 @@ export class Unit extends BaseEntity {
   @PrimaryColumn({
     name: 'unit_id',
     transformer: new NumericColumnTransformer(),
+    type: 'numeric',
   })
   id: number;
 


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6971

## Main Changes:

- In the `@Column` annotation for numeric types (integer and float), explicitly set the type to `numeric` to prevent TypeORM from coercing the value to an integer.