### PR TITLE
Updated anyOf Location Lookup Logic for validation & import phases (#6932)

### DIFF
--- a/src/qa-certification-workspace/qa-certification-checks.service.ts
+++ b/src/qa-certification-workspace/qa-certification-checks.service.ts
@@ -444,10 +444,12 @@ export class QACertificationChecksService {
         const location = locations.find(i => {
           if (qaCertEvent.stackPipeId) {
             // Always prefer stackPipeId when present
-            return i.stackPipeId === qaCertEvent.stackPipeId;
+            const match = i.stackPipeId === qaCertEvent.stackPipeId;
+            return match;
           } else if (qaCertEvent.unitId) {
             // Only use unitId if no stackPipeId provided
-            return i.unitId === qaCertEvent.unitId;
+            const match = i.unitId === qaCertEvent.unitId;
+            return match;
           }
           return false;
         });

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
 
 import { Logger } from '@us-epa-camd/easey-common/logger';
@@ -119,12 +119,24 @@ export class QACertificationWorkspaceService {
     payload.testSummaryData?.forEach((summary, idx) => {
       promises.push(
         new Promise((resolve, _reject) => {
-          const locationId = locations.find(i => {
-            return (
-              i.unitId === summary.unitId &&
-              i.stackPipeId === summary.stackPipeId
+          // Handle anyOf schema - either unitId OR stackPipeId (or both)
+          const location = locations.find(i => {
+            if (summary.unitId && summary.stackPipeId) {
+              return i.unitId === summary.unitId && i.stackPipeId === summary.stackPipeId;
+            } else if (summary.stackPipeId) {
+              return i.stackPipeId === summary.stackPipeId;
+            } else if (summary.unitId) {
+              return i.unitId === summary.unitId;
+            }
+            return false;
+          });
+
+          if (!location) {
+            throw new BadRequestException(
+              `Location not found for unitId: ${summary.unitId}, stackPipeId: ${summary.stackPipeId}`
             );
-          }).locationId;
+          }
+          const locationId = location.locationId;
 
           const results = this.testSummaryService.import(
             locationId,
@@ -143,12 +155,24 @@ export class QACertificationWorkspaceService {
       (qaTestExtensionExemptionId, idx) => {
         promises.push(
           new Promise((resolve, _reject) => {
-            const locationId = locations.find(i => {
-              return (
-                i.unitId === qaTestExtensionExemptionId.unitId &&
-                i.stackPipeId === qaTestExtensionExemptionId.stackPipeId
+            // Handle anyOf schema - either unitId OR stackPipeId (or both)
+            const location = locations.find(i => {
+              if (qaTestExtensionExemptionId.unitId && qaTestExtensionExemptionId.stackPipeId) {
+                return i.unitId === qaTestExtensionExemptionId.unitId && i.stackPipeId === qaTestExtensionExemptionId.stackPipeId;
+              } else if (qaTestExtensionExemptionId.stackPipeId) {
+                return i.stackPipeId === qaTestExtensionExemptionId.stackPipeId;
+              } else if (qaTestExtensionExemptionId.unitId) {
+                return i.unitId === qaTestExtensionExemptionId.unitId;
+              }
+              return false;
+            });
+
+            if (!location) {
+              throw new BadRequestException(
+                `Location not found for unitId: ${qaTestExtensionExemptionId.unitId}, stackPipeId: ${qaTestExtensionExemptionId.stackPipeId}`
               );
-            }).locationId;
+            }
+            const locationId = location.locationId;
 
             const results = this.testExtensionExemptionService.import(
               locationId,
@@ -164,12 +188,24 @@ export class QACertificationWorkspaceService {
     payload.certificationEventData?.forEach((qaCertEvent, idx) => {
       promises.push(
         new Promise((resolve, _reject) => {
-          const locationId = locations.find(i => {
-            return (
-              i.unitId === qaCertEvent.unitId &&
-              i.stackPipeId === qaCertEvent.stackPipeId
+          // Handle anyOf schema - either unitId OR stackPipeId (or both)
+          const location = locations.find(i => {
+            if (qaCertEvent.unitId && qaCertEvent.stackPipeId) {
+              return i.unitId === qaCertEvent.unitId && i.stackPipeId === qaCertEvent.stackPipeId;
+            } else if (qaCertEvent.stackPipeId) {
+              return i.stackPipeId === qaCertEvent.stackPipeId;
+            } else if (qaCertEvent.unitId) {
+              return i.unitId === qaCertEvent.unitId;
+            }
+            return false;
+          });
+
+          if (!location) {
+            throw new BadRequestException(
+              `Location not found for unitId: ${qaCertEvent.unitId}, stackPipeId: ${qaCertEvent.stackPipeId}`
             );
-          }).locationId;
+          }
+          const locationId = location.locationId;
 
           const results = this.qaCertEventService.import(
             locationId,

--- a/src/qa-certification-workspace/qa-certification.service.ts
+++ b/src/qa-certification-workspace/qa-certification.service.ts
@@ -28,6 +28,23 @@ export class QACertificationWorkspaceService {
     private readonly easeyContentService: EaseyContentService,
   ) {}
 
+  // Shared location lookup with priority-based matching (stackPipeId preferred)
+  private findLocationByIdentifiers(
+    locations: LocationIdentifiers[],
+    identifiers: { unitId?: string; stackPipeId?: string }
+  ): LocationIdentifiers | undefined {
+    return locations.find(i => {
+      if (identifiers.stackPipeId) {
+        // Always prefer stackPipeId when present (matches checks.service.ts logic)
+        return i.stackPipeId === identifiers.stackPipeId;
+      } else if (identifiers.unitId) {
+        // Only use unitId if no stackPipeId provided
+        return i.unitId === identifiers.unitId;
+      }
+      return false;
+    });
+  }
+
   async export(
     params: QACertificationParamsDTO,
     rptValuesOnly: boolean = false,
@@ -119,17 +136,8 @@ export class QACertificationWorkspaceService {
     payload.testSummaryData?.forEach((summary, idx) => {
       promises.push(
         new Promise((resolve, _reject) => {
-          // Handle anyOf schema - either unitId OR stackPipeId (or both)
-          const location = locations.find(i => {
-            if (summary.unitId && summary.stackPipeId) {
-              return i.unitId === summary.unitId && i.stackPipeId === summary.stackPipeId;
-            } else if (summary.stackPipeId) {
-              return i.stackPipeId === summary.stackPipeId;
-            } else if (summary.unitId) {
-              return i.unitId === summary.unitId;
-            }
-            return false;
-          });
+          //Use shared location lookup with priority-based matching
+          const location = this.findLocationByIdentifiers(locations, summary);
 
           if (!location) {
             throw new BadRequestException(
@@ -155,17 +163,8 @@ export class QACertificationWorkspaceService {
       (qaTestExtensionExemptionId, idx) => {
         promises.push(
           new Promise((resolve, _reject) => {
-            // Handle anyOf schema - either unitId OR stackPipeId (or both)
-            const location = locations.find(i => {
-              if (qaTestExtensionExemptionId.unitId && qaTestExtensionExemptionId.stackPipeId) {
-                return i.unitId === qaTestExtensionExemptionId.unitId && i.stackPipeId === qaTestExtensionExemptionId.stackPipeId;
-              } else if (qaTestExtensionExemptionId.stackPipeId) {
-                return i.stackPipeId === qaTestExtensionExemptionId.stackPipeId;
-              } else if (qaTestExtensionExemptionId.unitId) {
-                return i.unitId === qaTestExtensionExemptionId.unitId;
-              }
-              return false;
-            });
+            // Use shared location lookup with priority-based matching
+            const location = this.findLocationByIdentifiers(locations, qaTestExtensionExemptionId);
 
             if (!location) {
               throw new BadRequestException(
@@ -188,17 +187,8 @@ export class QACertificationWorkspaceService {
     payload.certificationEventData?.forEach((qaCertEvent, idx) => {
       promises.push(
         new Promise((resolve, _reject) => {
-          // Handle anyOf schema - either unitId OR stackPipeId (or both)
-          const location = locations.find(i => {
-            if (qaCertEvent.unitId && qaCertEvent.stackPipeId) {
-              return i.unitId === qaCertEvent.unitId && i.stackPipeId === qaCertEvent.stackPipeId;
-            } else if (qaCertEvent.stackPipeId) {
-              return i.stackPipeId === qaCertEvent.stackPipeId;
-            } else if (qaCertEvent.unitId) {
-              return i.unitId === qaCertEvent.unitId;
-            }
-            return false;
-          });
+          // Use shared location lookup with priority-based matching
+          const location = this.findLocationByIdentifiers(locations, qaCertEvent);
 
           if (!location) {
             throw new BadRequestException(


### PR DESCRIPTION
 ### Summary:
During testing import crashes when importing files containing records with both unitId and stackPipeIdidentifiers. The existing
anyOf logic required exact matches for both fields when provided together, but database locations typically only match one identifier

### Root Cause: 
Mixed data patterns in QA files:
json [ { "stackPipeId`": "CS0AAN", `"unitId":` `null` }, // Works fine { "`stackPipeId`": "CS0AAN", `"`unitId`":` "`AA2`" } // Crashed - no exact match]

### Changes Made: 
  - **Validation phase**: AND logic required both fields
  - **Import phase**: Missing anyOf logic caused undefined access crashes
  
 ### Testing:
- Unit tests pass with new priority-based scenarios
- Existing functionality preserved
- QA validated with actual mixed data files
