### PR TITLE
fix: use metadata_rpt_type_cd for ReportTypeCode in MATS submission XML

### DIFF
--- a/src/mats-data-submission/mats-data-submission.service.spec.ts
+++ b/src/mats-data-submission/mats-data-submission.service.spec.ts
@@ -12,6 +12,7 @@ import { Plant } from '../entities/plant.entity';
 import { MatsDataSubmissionMap } from '../maps/mats-data-submission.map';
 import { MatsDataSubmissionRepository } from './mats-data-submission.repository';
 import { MatsDataSubmissionService } from './mats-data-submission.service';
+import { MatsReportTypeCode } from '../entities/mats-report-type-code.entity';
 
 const mockDate = new Date();
 function createMockSubmission() {
@@ -20,6 +21,9 @@ function createMockSubmission() {
   pollutant.metadataPollutantCode = 'ANY';
   const testMethod = new MatsTestMethodCode();
   testMethod.code = 'MTH';
+
+  const reportType = new MatsReportTypeCode();
+  reportType.metadataReportTypeCode = 'RPT'; 
 
   entity.addTime = mockDate;
   entity.averagingGroupCode = 'AGC';
@@ -34,6 +38,7 @@ function createMockSubmission() {
   entity.pollutants = [pollutant];
   entity.quarter = 1;
   entity.reportTypeCode = 'RPT';
+  entity.reportType = reportType;
   entity.testComment = 'Test Comment';
   entity.testDate = mockDate;
   entity.testMethods = [testMethod];

--- a/src/mats-data-submission/mats-data-submission.service.ts
+++ b/src/mats-data-submission/mats-data-submission.service.ts
@@ -305,6 +305,7 @@ export class MatsDataSubmissionService {
         },
         pollutants: true,
         testMethods: true,
+        reportType: true
       },
     });
     if (!record) {
@@ -323,7 +324,7 @@ export class MatsDataSubmissionService {
           OriginalSubmissionId: record.originalSubmissionId,
         },
         CdxUser: record.userId,
-        ReportTypeCode: record.reportTypeCode,
+        ReportTypeCode: record.reportType?.metadataReportTypeCode || record.reportTypeCode,
         OrisCode: record.facility.orisCode,
         FrsId: record.facility.frsId ?? '',
         LocationName:

--- a/src/mats-data-submission/mats-data-submission.service.ts
+++ b/src/mats-data-submission/mats-data-submission.service.ts
@@ -324,7 +324,7 @@ export class MatsDataSubmissionService {
           OriginalSubmissionId: record.originalSubmissionId,
         },
         CdxUser: record.userId,
-        ReportTypeCode: record.reportType?.metadataReportTypeCode || record.reportTypeCode,
+        ReportTypeCode: record.reportType.metadataReportTypeCode,
         OrisCode: record.facility.orisCode,
         FrsId: record.facility.frsId ?? '',
         LocationName:


### PR DESCRIPTION
## Ticket
[MATS Data Submission: Correct Report Type Code Included in the Metadata XML](https://github.com/US-EPA-CAMD/easey-ui/issues/7089)

## Changes
Updated mats-data-submission.service.ts to use metadataReportTypeCode from the MatsReportTypeCode entity instead of the mats_rpt_type_cd value