### PR TITLE
Temporary fix to restart qa-cert every morning at 2:05am 

### DIFF
--- a/.github/workflows/daily-restart.yml
+++ b/.github/workflows/daily-restart.yml
@@ -1,0 +1,30 @@
+name: Daily Restart
+
+on:
+  schedule:
+    - cron: '5 7 * * *'  # 2:05 AM ET (7:05 AM UTC)
+  workflow_dispatch:
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    environment:
+      name: Production
+    steps:
+      - name: Checkout devops repo
+        uses: actions/checkout@v3
+        with:
+          repository: US-EPA-CAMD/devops
+          path: devops
+      - name: Install cf cli
+        run: devops/scripts/install-cf-cli.sh
+      - name: Login to cloud.gov
+        run: devops/scripts/cf-login.sh
+        env:
+          CF_USERNAME: ${{ secrets.CF_PROD_DEPLOYMENT_SVC }}
+          CF_PASSWORD: ${{ secrets.CF_PROD_DEPLOYMENT_SVC_PWD }}
+          CF_API_URL: https://api.fr.cloud.gov
+          CF_ORG_NAME: epa-easey
+          CF_ORG_SPACE: prod
+      - name: Restart qa-certification-api
+        run: cf restart qa-certification-api


### PR DESCRIPTION
Temporary fix to restart qa-cert every morning at 2:05am until a fix is deployed.